### PR TITLE
Wire Up Apollo — Snacksby Can Now Talk to Its Database

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import './globals.css'
 
+import { ApolloClientProvider } from '@/components/apollo-provider'
 import { SessionProvider } from '@/components/session-provider'
 import { getUserAndSession } from '@/lib/supabase/session'
 
@@ -20,7 +21,7 @@ export default async function RootLayout({
 		<html lang="en" data-theme="mytheme-light">
 			<body className="bg-neutral text-neutral-content flex items-center justify-center min-h-screen">
 				<SessionProvider user={user} session={session}>
-					{children}
+					<ApolloClientProvider>{children}</ApolloClientProvider>
 				</SessionProvider>
 			</body>
 		</html>

--- a/src/components/apollo-provider.tsx
+++ b/src/components/apollo-provider.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { ApolloProvider } from '@apollo/client/react'
+
 import apolloClient from '@/lib/apollo'
 
 export function ApolloClientProvider({

--- a/src/components/apollo-provider.tsx
+++ b/src/components/apollo-provider.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import { ApolloProvider } from '@apollo/client/react'
+import apolloClient from '@/lib/apollo'
+
+export function ApolloClientProvider({
+	children,
+}: {
+	children: React.ReactNode
+}) {
+	return <ApolloProvider client={apolloClient}>{children}</ApolloProvider>
+}

--- a/src/lib/apollo.ts
+++ b/src/lib/apollo.ts
@@ -19,7 +19,6 @@ const authLink = new SetContextLink(async (prevContext) => {
 	return {
 		headers: {
 			...headers,
-			apikey: process.env.SUPABASE_ANON_KEY,
 			Authorization: session?.access_token
 				? `Bearer ${session.access_token}`
 				: '',


### PR DESCRIPTION
# Wire Up Apollo — Snacksby Can Now Talk to Its Database

## Overview
This branch completes the foundational Apollo Client setup — configuring the client, fixing CI environment variables, upgrading to Next.js 16, and finally wiring `ApolloProvider` into the root layout so components can actually use it.

> [!TIP]
> No steps required after pulling. No new env vars — existing `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` are all that's needed.

## Changes

<details>
<summary><strong>Apollo Client</strong></summary>

- `src/lib/apollo.ts` — configures the client with an auth link (injects Supabase JWT per request) and an HTTP link pointing to Supabase's GraphQL endpoint. Removed a redundant `apikey` header that was already set in `httpLink`.
- `src/components/apollo-provider.tsx` — new client component wrapping `ApolloProvider` with the configured client.
- `src/app/layout.tsx` — mounts `ApolloClientProvider` inside `SessionProvider`, making `useQuery`/`useMutation` available app-wide.

</details>

<details>
<summary><strong>Next.js 16 Upgrade & Config</strong></summary>

- `package.json` — Next.js bumped to 16.2.1, React to 19.2.4, devDependencies modernised.
- `next.config.ts` — migrated to `.ts`.
- `tsconfig.json`, `postcss.config.mjs`, `eslint.config.mjs` — updated for compatibility.
- `.prettierrc` — config updated.

</details>

<details>
<summary><strong>CI Workflows</strong></summary>

- `.github/workflows/lint.yml` and `typescript.yml` — upgraded to `actions/checkout@v4`, `actions/setup-node@v4`, Node 22, and fixed env var names to use the correct `NEXT_PUBLIC_` prefix.

</details>

---

## Summary
This PR is like finally plugging the kettle in. The kettle (Apollo Client) has been sitting on the counter looking great, but nobody had actually put it in the socket. Now it's wired up, the auth token goes in, and Supabase GraphQL comes out — hot and ready.