### PR TITLE
Settings Account Section — Complete Email & Password Management

### DIFF
--- a/src/app/settings/account-section.tsx
+++ b/src/app/settings/account-section.tsx
@@ -1,0 +1,169 @@
+'use client'
+
+import { useActionState, useState } from 'react'
+
+import { updateEmail, updatePassword } from './actions'
+
+interface Props {
+	email: string
+}
+
+export function AccountSection({ email }: Props) {
+	const [emailOpen, setEmailOpen] = useState(false)
+	const [passwordOpen, setPasswordOpen] = useState(false)
+
+	const [emailState, emailAction] = useActionState(updateEmail, {
+		error: '',
+		success: '',
+	})
+	const [passwordState, passwordAction] = useActionState(updatePassword, {
+		error: '',
+		success: '',
+	})
+
+	return (
+		<section className="space-y-4">
+			<div className="card bg-base-100 shadow-md">
+				<div className="card-body gap-4">
+					<div className="flex items-center justify-between">
+						<div>
+							<h2 className="card-title text-lg">Email address</h2>
+							<p className="text-base-content/60 text-sm">{email}</p>
+						</div>
+						<button
+							className="btn btn-sm btn-ghost"
+							onClick={() => setEmailOpen((o) => !o)}
+						>
+							{emailOpen ? 'Cancel' : 'Change'}
+						</button>
+					</div>
+
+					{emailOpen && (
+						<form action={emailAction} className="flex flex-col gap-3">
+							<div className="form-control gap-1">
+								<label htmlFor="new-email" className="label-text font-medium">
+									New email
+								</label>
+								<input
+									id="new-email"
+									type="email"
+									name="email"
+									placeholder="new@example.com"
+									className="input input-bordered w-full"
+									required
+								/>
+							</div>
+							<div className="form-control gap-1">
+								<label
+									htmlFor="email-password"
+									className="label-text font-medium"
+								>
+									Current password
+								</label>
+								<input
+									id="email-password"
+									type="password"
+									name="password"
+									placeholder="••••••••"
+									className="input input-bordered w-full"
+									required
+								/>
+							</div>
+							{emailState.error && (
+								<p className="text-error text-sm">{emailState.error}</p>
+							)}
+							{emailState.success && (
+								<p className="text-success text-sm">{emailState.success}</p>
+							)}
+							<button
+								type="submit"
+								className="btn btn-primary btn-sm self-start"
+							>
+								Update email
+							</button>
+						</form>
+					)}
+				</div>
+			</div>
+
+			<div className="card bg-base-100 shadow-md">
+				<div className="card-body gap-4">
+					<div className="flex items-center justify-between">
+						<div>
+							<h2 className="card-title text-lg">Password</h2>
+							<p className="text-base-content/60 text-sm">••••••••</p>
+						</div>
+						<button
+							className="btn btn-sm btn-ghost"
+							onClick={() => setPasswordOpen((o) => !o)}
+						>
+							{passwordOpen ? 'Cancel' : 'Change'}
+						</button>
+					</div>
+
+					{passwordOpen && (
+						<form action={passwordAction} className="flex flex-col gap-3">
+							<div className="form-control gap-1">
+								<label
+									htmlFor="currentPassword"
+									className="label-text font-medium"
+								>
+									Current password
+								</label>
+								<input
+									id="currentPassword"
+									type="password"
+									name="currentPassword"
+									placeholder="••••••••"
+									className="input input-bordered w-full"
+									required
+								/>
+							</div>
+							<div className="form-control gap-1">
+								<label htmlFor="newPassword" className="label-text font-medium">
+									New password
+								</label>
+								<input
+									id="newPassword"
+									type="password"
+									name="newPassword"
+									placeholder="••••••••"
+									className="input input-bordered w-full"
+									required
+								/>
+							</div>
+							<div className="form-control gap-1">
+								<label
+									htmlFor="confirmPassword"
+									className="label-text font-medium"
+								>
+									Confirm new password
+								</label>
+								<input
+									id="confirmPassword"
+									type="password"
+									name="confirmPassword"
+									placeholder="••••••••"
+									className="input input-bordered w-full"
+									required
+								/>
+							</div>
+							{passwordState.error && (
+								<p className="text-error text-sm">{passwordState.error}</p>
+							)}
+							{passwordState.success && (
+								<p className="text-success text-sm">{passwordState.success}</p>
+							)}
+							<button
+								type="submit"
+								className="btn btn-primary btn-sm self-start"
+							>
+								Update password
+							</button>
+						</form>
+					)}
+				</div>
+			</div>
+		</section>
+	)
+}

--- a/src/app/settings/actions.ts
+++ b/src/app/settings/actions.ts
@@ -1,0 +1,59 @@
+'use server'
+
+import { serverClient } from '@/lib/supabase/server'
+
+export async function updateEmail(
+	_prevState: { error: string; success: string },
+	formData: FormData,
+): Promise<{ error: string; success: string }> {
+	const newEmail = (formData.get('email') as string)?.trim() ?? ''
+	const password = (formData.get('password') as string) ?? ''
+
+	if (!newEmail) return { error: 'Email is required.', success: '' }
+
+	const supabase = await serverClient()
+	const {
+		data: { user },
+	} = await supabase.auth.getUser()
+	if (!user?.email) return { error: 'Not authenticated.', success: '' }
+
+	const { error: authError } = await supabase.auth.signInWithPassword({
+		email: user.email,
+		password,
+	})
+	if (authError) return { error: 'Password is incorrect.', success: '' }
+
+	const { error } = await supabase.auth.updateUser({ email: newEmail })
+	if (error) return { error: error.message, success: '' }
+	return { error: '', success: 'Confirmation sent. Check both inboxes.' }
+}
+
+export async function updatePassword(
+	_prevState: { error: string; success: string },
+	formData: FormData,
+): Promise<{ error: string; success: string }> {
+	const currentPassword = (formData.get('currentPassword') as string) ?? ''
+	const newPassword = (formData.get('newPassword') as string) ?? ''
+	const confirmPassword = (formData.get('confirmPassword') as string) ?? ''
+
+	if (newPassword !== confirmPassword)
+		return { error: 'New passwords do not match.', success: '' }
+	if (newPassword.length < 8)
+		return { error: 'Password must be at least 8 characters.', success: '' }
+
+	const supabase = await serverClient()
+	const {
+		data: { user },
+	} = await supabase.auth.getUser()
+	if (!user?.email) return { error: 'Not authenticated.', success: '' }
+
+	const { error: authError } = await supabase.auth.signInWithPassword({
+		email: user.email,
+		password: currentPassword,
+	})
+	if (authError) return { error: 'Current password is incorrect.', success: '' }
+
+	const { error } = await supabase.auth.updateUser({ password: newPassword })
+	if (error) return { error: error.message, success: '' }
+	return { error: '', success: 'Password updated.' }
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,17 +1,13 @@
-export default function SettingsPage() {
+import { AccountSection } from './account-section'
+import { getUserAndSession } from '@/lib/supabase/session'
+
+export default async function SettingsPage() {
+	const { user } = await getUserAndSession()
+
 	return (
 		<div className="p-4 space-y-6">
 			<h1 className="text-2xl font-bold">Settings</h1>
-
-			<section className="card bg-base-100 shadow-md">
-				<div className="card-body">
-					<h2 className="card-title text-lg">Account</h2>
-					<p className="text-base-content/60">
-						Email and password settings coming soon.
-					</p>
-				</div>
-			</section>
-
+			<AccountSection email={user?.email ?? ''} />
 			<section className="card bg-base-100 shadow-md">
 				<div className="card-body">
 					<h2 className="card-title text-lg">Household</h2>


### PR DESCRIPTION
# Settings Account Section — Complete Email & Password Management

## Overview
Implements the account section of the Settings page (`1SET.1`), completing Milestone 1. Users can update their email address or password via collapsible forms — hidden by default to avoid an aggressive first impression.

> [!TIP]
> No local setup needed. Hit `/settings` when logged in to test both flows.

## Changes

<details>
<summary>Settings page & components</summary>

- `settings/page.tsx` — converted to async server component; fetches current user email to display
- `settings/account-section.tsx` — client component with collapsible Change Email and Change Password forms; both hidden behind a toggle button
- `settings/actions.ts` — two server actions: `updateEmail` and `updatePassword`

</details>

<details>
<summary>Security</summary>

- Both actions require the current password before applying any change
- `updatePassword` re-authenticates via `signInWithPassword` before calling `updateUser`
- `updateEmail` does the same — prevents session-hijack account takeover

</details>

---

## Summary
Like a good bouncer, the forms don't let you in until you prove who you are — and they don't even show themselves until you knock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)