### PR TITLE
Full Recipe CRUD — Browse, View, Create, Edit & Delete

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -48,12 +48,13 @@ Junction table. Composite PK on `(household_id, user_id)` — enforces one membe
 ---
 
 ### `recipes`
-Scoped to a household. `ingredients` and `procedure` stored as JSON for flexibility.
 
 | Column | Type | Notes |
 |---|---|---|
 | `id` | `uuid` | PK |
-| `household_id` | `uuid` | FK → `households.id` |
+| `created_by` | `uuid` | FK → `profiles.id` — tracks authorship; persists after leaving a household |
+| `household_id` | `uuid` | FK → `households.id`, nullable — null if creator has left their household |
+| `visibility` | `visibility_type` | Enum: `private`, `public`. Defaults to `private` |
 | `title` | `text` | |
 | `description` | `text` | Nullable |
 | `servings` | `int` | Nullable |
@@ -63,6 +64,12 @@ Scoped to a household. `ingredients` and `procedure` stored as JSON for flexibil
 | `procedure` | `json` | Unstructured for MVP |
 | `tags` | `text[]` | |
 | `created_at` | `timestamptz` | |
+
+**Visibility rules:**
+- `private` — readable only by creator
+- `public` — readable by any authenticated user
+
+**Household scoping:** recipes with `household_id = mine` form the shared household collection ("My Recipes"). On leaving a household, `created_by = auth.uid()` ensures access to your own recipes is retained.
 
 ---
 
@@ -113,7 +120,7 @@ Most policies subquery `household_members` to verify the current user (`auth.uid
 | `household_members` | Select | Members of the same household |
 | `household_members` | Insert | Self-join (one household per user) or Leader adding another |
 | `household_members` | Delete | Leader (remove others) or self (leave) |
-| `recipes` | Select | Any household member |
+| `recipes` | Select | Household member, creator, or `visibility = public` |
 | `recipes` | Insert, Update, Delete | Leader or Contributor |
 | `meal_plan` | Select | Any household member |
 | `meal_plan` | Insert, Update, Delete | Leader or Contributor |

--- a/docs/database.md
+++ b/docs/database.md
@@ -61,7 +61,7 @@ Junction table. Composite PK on `(household_id, user_id)` — enforces one membe
 | `prep_time` | `int` | Minutes, nullable |
 | `cook_time` | `int` | Minutes, nullable |
 | `ingredients` | `json` | Unstructured for MVP |
-| `procedure` | `json` | Unstructured for MVP |
+| `method` | `json` | Unstructured for MVP |
 | `tags` | `text[]` | |
 | `created_at` | `timestamptz` | |
 

--- a/docs/roadmaps/mvp.md
+++ b/docs/roadmaps/mvp.md
@@ -10,11 +10,11 @@ description: MVP roadmap for Snacksby — collaborative meal planning PWA
 | **NAV**   | Done                                      | —                              | —                 |
 | **SET**   | Done                                      | —                              | 1SET.2 → `3HH.4`  |
 | **DB**    | Done — tables, RLS, GraphQL verified      | —                              | —                 |
-| **REC**   | Browse, detail, create, edit live         | Delete                         | —                 |
+| **REC**   | Done — full CRUD live                     | —                              | —                 |
 | **HH/RL** | Partial — role enum done                  | Household creation flow        | —                 |
-| **PL**    | Stub only                                 | Weekly calendar view           | `2REC.*`, `3HH.*` |
+| **PL**    | Stub only                                 | Weekly calendar view           | `3HH.*`           |
 | **SH**    | Wireframe only (local state)              | DB persistence                 | `4PL.2`           |
-| **PWA**   | Not started                               | PWA manifest                   | `5SH.2`, `2REC.2` |
+| **PWA**   | Not started                               | PWA manifest                   | `5SH.2`           |
 
 ---
 
@@ -82,8 +82,7 @@ _(none)_
 
 <a name="m2-todo"><h4>To Do (Milestone 2)</h4></a>
 
-- [x] 2REC.5. Edit recipe form + GraphQL update mutation
-- [ ] 2REC.6. Delete recipe with GraphQL mutation — **depends on 2REC.5**
+_(none)_
 
 <a name="m2-blocked"><h4>Blocked (Milestone 2)</h4></a>
 
@@ -95,6 +94,8 @@ _(none)_
 - [x] 2REC.2. Recipe browse page connected to live data — Explore tab queries public recipes; My Recipes stubbed pending M3 household context
 - [x] 2REC.3. Recipe detail page (title, servings, structured ingredients, method)
 - [x] 2REC.4. Add recipe form + GraphQL create mutation
+- [x] 2REC.5. Edit recipe form + GraphQL update mutation
+- [x] 2REC.6. Delete recipe with GraphQL mutation + confirmation modal
 
 ---
 
@@ -147,7 +148,7 @@ _(none)_
 
 <a name="m4-blocked"><h4>Blocked (Milestone 4)</h4></a>
 
-- `4PL.2` and beyond blocked on `3HH.1` (household creation) and `2REC.2` (live recipe data)
+- `4PL.2` and beyond blocked on `3HH.1` (household creation)
 - `4PL.1` and `4PL.5` are unblocked (UI only)
 
 <a name="m4-done"><h4>Completed (Milestone 4)</h4></a>
@@ -182,7 +183,8 @@ _(none)_
 <a name="m5-blocked"><h4>Blocked (Milestone 5)</h4></a>
 
 - `5SH.1` is unblocked (DB is ready)
-- `5SH.3` and `5PWA.2` blocked on M4 and M2 completion respectively
+- `5SH.3` blocked on `4PL.2` (meal plan query)
+- `5PWA.2` blocked on `5SH.2`
 
 <a name="m5-done"><h4>Completed (Milestone 5)</h4></a>
 
@@ -221,12 +223,6 @@ M5["`**Milestone 5**<br/>Shopping List & PWA`"]:::mile
 "1DB.2"["`*1DB.2*<br/>**DB**<br/>Create tables`"]:::done
 "1DB.3"["`*1DB.3*<br/>**DB**<br/>RLS policies`"]:::done
 "1DB.4"["`*1DB.4*<br/>**DB**<br/>Verify GraphQL`"]:::done
-
-%% ─── Milestone 2: Recipes ────────────────────────────────────────────────────
-"2REC.5"["`*2REC.5*<br/>**REC**<br/>Edit recipe`"]:::open
-"2REC.6"["`*2REC.6*<br/>**REC**<br/>Delete recipe`"]:::blocked
-
-"2REC.5" --> "2REC.6"
 
 %% ─── Milestone 3: Households & Roles ────────────────────────────────────────
 "3RL.1"["`*3RL.1*<br/>**RL**<br/>Role enum in DB`"]:::done
@@ -313,6 +309,6 @@ Features deliberately deferred from the MVP:
 
 ---
 
-_Last updated: 2026-04-24_
+_Last updated: 2026-04-27_
 
 

--- a/docs/roadmaps/mvp.md
+++ b/docs/roadmaps/mvp.md
@@ -293,6 +293,14 @@ classDef done fill:#bbf7d0,stroke:#16a34a,color:#14532d
 
 ---
 
+<a name="polish"><h2>Polish</h2></a>
+
+UI improvements to revisit once all milestones are complete:
+
+- **Tag filtering persistence** — move `activeTag` state on the browse page to a URL search param (`?tag=pasta`); link tag badges on the recipe detail page back to `/recipes?tag=...` so the filter survives navigation
+
+---
+
 <a name="post-mvp"><h2>Beyond MVP</h2></a>
 
 Features deliberately deferred from the MVP:
@@ -306,6 +314,6 @@ Features deliberately deferred from the MVP:
 
 ---
 
-_Last updated: 2026-04-22_
+_Last updated: 2026-04-23_
 
 

--- a/docs/roadmaps/mvp.md
+++ b/docs/roadmaps/mvp.md
@@ -10,7 +10,7 @@ description: MVP roadmap for Snacksby — collaborative meal planning PWA
 | **NAV**   | Done                                      | —                              | —                 |
 | **SET**   | Done                                      | —                              | 1SET.2 → `3HH.4`  |
 | **DB**    | Done — tables, RLS, GraphQL verified      | —                              | —                 |
-| **REC**   | Explore tab live (public recipes)         | Detail page, add/edit/delete   | —                 |
+| **REC**   | Browse, detail, create, edit live         | Delete                         | —                 |
 | **HH/RL** | Partial — role enum done                  | Household creation flow        | —                 |
 | **PL**    | Stub only                                 | Weekly calendar view           | `2REC.*`, `3HH.*` |
 | **SH**    | Wireframe only (local state)              | DB persistence                 | `4PL.2`           |
@@ -82,18 +82,19 @@ _(none)_
 
 <a name="m2-todo"><h4>To Do (Milestone 2)</h4></a>
 
-- [ ] 2REC.3. Recipe detail page (title, servings, structured ingredients, method)
-- [ ] 2REC.4. Add recipe form + GraphQL create mutation
+- [x] 2REC.5. Edit recipe form + GraphQL update mutation
+- [ ] 2REC.6. Delete recipe with GraphQL mutation — **depends on 2REC.5**
 
 <a name="m2-blocked"><h4>Blocked (Milestone 2)</h4></a>
 
-- [ ] 2REC.5. Edit recipe form + GraphQL update mutation — **depends on 2REC.4**
-- [ ] 2REC.6. Delete recipe with GraphQL mutation — **depends on 2REC.5**
+_(none)_
 
 <a name="m2-done"><h4>Completed (Milestone 2)</h4></a>
 
 - [x] 2REC.1. GraphQL queries written — `GET_PUBLIC_RECIPES` and `GET_MY_RECIPES` (or-filter covering household + created-by)
 - [x] 2REC.2. Recipe browse page connected to live data — Explore tab queries public recipes; My Recipes stubbed pending M3 household context
+- [x] 2REC.3. Recipe detail page (title, servings, structured ingredients, method)
+- [x] 2REC.4. Add recipe form + GraphQL create mutation
 
 ---
 
@@ -222,12 +223,9 @@ M5["`**Milestone 5**<br/>Shopping List & PWA`"]:::mile
 "1DB.4"["`*1DB.4*<br/>**DB**<br/>Verify GraphQL`"]:::done
 
 %% ─── Milestone 2: Recipes ────────────────────────────────────────────────────
-"2REC.3"["`*2REC.3*<br/>**REC**<br/>Detail page`"]:::open
-"2REC.4"["`*2REC.4*<br/>**REC**<br/>Add recipe`"]:::open
-"2REC.5"["`*2REC.5*<br/>**REC**<br/>Edit recipe`"]:::blocked
+"2REC.5"["`*2REC.5*<br/>**REC**<br/>Edit recipe`"]:::open
 "2REC.6"["`*2REC.6*<br/>**REC**<br/>Delete recipe`"]:::blocked
 
-"2REC.4" --> "2REC.5"
 "2REC.5" --> "2REC.6"
 
 %% ─── Milestone 3: Households & Roles ────────────────────────────────────────
@@ -298,6 +296,7 @@ classDef done fill:#bbf7d0,stroke:#16a34a,color:#14532d
 UI improvements to revisit once all milestones are complete:
 
 - **Tag filtering persistence** — move `activeTag` state on the browse page to a URL search param (`?tag=pasta`); link tag badges on the recipe detail page back to `/recipes?tag=...` so the filter survives navigation
+- **Recipe saved banner** — if create/edit mutation succeeds but returns no ID, the user is redirected to `/recipes` without confirmation; show a transient "Recipe saved" banner on the list page via a query param (`?saved=1`) so they know it worked
 
 ---
 
@@ -314,6 +313,6 @@ Features deliberately deferred from the MVP:
 
 ---
 
-_Last updated: 2026-04-23_
+_Last updated: 2026-04-24_
 
 

--- a/docs/roadmaps/mvp.md
+++ b/docs/roadmaps/mvp.md
@@ -8,9 +8,9 @@ description: MVP roadmap for Snacksby — collaborative meal planning PWA
 | --------- | ----------------------------------------- | ------------------------------ | ----------------- |
 | **INF**   | Done                                      | —                              | —                 |
 | **NAV**   | Done                                      | —                              | —                 |
-| **SET**   | Stub only                                 | Account section (1SET.1)       | 1SET.2 → `3HH.4`  |
+| **SET**   | Done                                      | —                              | 1SET.2 → `3HH.4`  |
 | **DB**    | Done — tables, RLS, GraphQL verified      | —                              | —                 |
-| **REC**   | Wireframe only (mock data, at `/recipes`) | GraphQL queries                | —                 |
+| **REC**   | Explore tab live (public recipes)         | Detail page, add/edit/delete   | —                 |
 | **HH/RL** | Partial — role enum done                  | Household creation flow        | —                 |
 | **PL**    | Stub only                                 | Weekly calendar view           | `2REC.*`, `3HH.*` |
 | **SH**    | Wireframe only (local state)              | DB persistence                 | `4PL.2`           |
@@ -44,7 +44,7 @@ _(none)_
 
 <a name="m1-todo"><h4>To Do (Milestone 1)</h4></a>
 
-- [ ] 1SET.1. Settings page — account section (email, password) — **depends on 1NAV.3**
+_(none)_
 
 <a name="m1-blocked"><h4>Blocked (Milestone 1)</h4></a>
 
@@ -67,6 +67,7 @@ _(none)_
 - [x] 1DB.2. Create Supabase tables — role_type enum (Leader/Contributor/Member), all FK relationships
 - [x] 1DB.3. RLS policies — per-table read/write rules enforcing household membership and role; one household per user enforced at insert
 - [x] 1DB.4. GraphQL schema verified via introspection — all collections and relations confirmed
+- [x] 1SET.1. Settings page — account section (email, password change); both actions require current password verification
 
 ---
 
@@ -81,20 +82,18 @@ _(none)_
 
 <a name="m2-todo"><h4>To Do (Milestone 2)</h4></a>
 
-- [ ] 2REC.1. Write GraphQL query — fetch recipes list
-- [ ] 2REC.2. Connect recipe browse page to live data (replace mock data) — **depends on 2REC.1**
-- [ ] 2REC.3. Recipe detail page (title, servings, structured ingredients, method) — **depends on 2REC.2**
-- [ ] 2REC.4. Add recipe form + GraphQL create mutation — **depends on 2REC.1**
-- [ ] 2REC.5. Edit recipe form + GraphQL update mutation — **depends on 2REC.4**
-- [ ] 2REC.6. Delete recipe with GraphQL mutation — **depends on 2REC.5**
+- [ ] 2REC.3. Recipe detail page (title, servings, structured ingredients, method)
+- [ ] 2REC.4. Add recipe form + GraphQL create mutation
 
 <a name="m2-blocked"><h4>Blocked (Milestone 2)</h4></a>
 
-_(none — fully unblocked)_
+- [ ] 2REC.5. Edit recipe form + GraphQL update mutation — **depends on 2REC.4**
+- [ ] 2REC.6. Delete recipe with GraphQL mutation — **depends on 2REC.5**
 
 <a name="m2-done"><h4>Completed (Milestone 2)</h4></a>
 
-_(none)_
+- [x] 2REC.1. GraphQL queries written — `GET_PUBLIC_RECIPES` and `GET_MY_RECIPES` (or-filter covering household + created-by)
+- [x] 2REC.2. Recipe browse page connected to live data — Explore tab queries public recipes; My Recipes stubbed pending M3 household context
 
 ---
 
@@ -223,16 +222,11 @@ M5["`**Milestone 5**<br/>Shopping List & PWA`"]:::mile
 "1DB.4"["`*1DB.4*<br/>**DB**<br/>Verify GraphQL`"]:::done
 
 %% ─── Milestone 2: Recipes ────────────────────────────────────────────────────
-"2REC.1"["`*2REC.1*<br/>**REC**<br/>Query recipes`"]:::open
-"2REC.2"["`*2REC.2*<br/>**REC**<br/>Connect browse page`"]:::blocked
-"2REC.3"["`*2REC.3*<br/>**REC**<br/>Detail page`"]:::blocked
-"2REC.4"["`*2REC.4*<br/>**REC**<br/>Add recipe`"]:::blocked
+"2REC.3"["`*2REC.3*<br/>**REC**<br/>Detail page`"]:::open
+"2REC.4"["`*2REC.4*<br/>**REC**<br/>Add recipe`"]:::open
 "2REC.5"["`*2REC.5*<br/>**REC**<br/>Edit recipe`"]:::blocked
 "2REC.6"["`*2REC.6*<br/>**REC**<br/>Delete recipe`"]:::blocked
 
-"2REC.1" --> "2REC.2"
-"2REC.1" --> "2REC.4"
-"2REC.2" --> "2REC.3"
 "2REC.4" --> "2REC.5"
 "2REC.5" --> "2REC.6"
 
@@ -264,7 +258,6 @@ M5["`**Milestone 5**<br/>Shopping List & PWA`"]:::mile
 "4PL.1" --> "4PL.5"
 "4PL.2" --> "4PL.3"
 "4PL.2" --> "4PL.6"
-"2REC.2" --> "4PL.3"
 "4PL.3" --> "4PL.4"
 "3HH.1" --> "4PL.6"
 
@@ -289,7 +282,6 @@ M5["`**Milestone 5**<br/>Shopping List & PWA`"]:::mile
 "5SH.2" --> "5SH.6"
 "5SH.2" --> "5SH.7"
 "5SH.2" --> "5PWA.2"
-"2REC.2" --> "5PWA.2"
 "5PWA.2" --> "5PWA.3"
 "5PWA.2" --> "5PWA.4"
 
@@ -315,3 +307,5 @@ Features deliberately deferred from the MVP:
 ---
 
 _Last updated: 2026-04-22_
+
+

--- a/scripts/seed.sql
+++ b/scripts/seed.sql
@@ -1,0 +1,50 @@
+INSERT INTO recipes (id, created_by, household_id, visibility, title, description, servings, prep_time, cook_time, ingredients, method, tags)
+VALUES
+(
+  gen_random_uuid(),
+  (SELECT id FROM profiles LIMIT 1),
+  NULL,
+  'public',
+  'Spaghetti Bolognese',
+  'A rich, slow-cooked meat sauce served over spaghetti.',
+  4, 15, 45,
+  $$[{"name":"beef mince","quantity":"500g"},{"name":"spaghetti","quantity":"400g"},{"name":"onion","quantity":"1 large"},{"name":"garlic cloves","quantity":"3"},{"name":"chopped tomatoes","quantity":"400g tin"},{"name":"tomato puree","quantity":"2 tbsp"},{"name":"red wine","quantity":"150ml"},{"name":"beef stock","quantity":"150ml"},{"name":"olive oil","quantity":"2 tbsp"}]$$::jsonb,
+  $$[{"step":1,"instruction":"Finely dice the onion and crush the garlic."},{"step":2,"instruction":"Heat olive oil in a large pan over medium heat. Soften the onion for 5 minutes, then add the garlic and cook for 1 minute more."},{"step":3,"instruction":"Add the beef mince, breaking it up with a spoon, and brown all over."},{"step":4,"instruction":"Stir in the tomato puree, then pour in the red wine. Simmer for 2 minutes."},{"step":5,"instruction":"Add the chopped tomatoes and stock. Season well, reduce heat to low, and simmer uncovered for 35 minutes."},{"step":6,"instruction":"Cook spaghetti according to packet instructions. Drain and serve topped with the Bolognese."}]$$::jsonb,
+  ARRAY['pasta','italian','dinner']
+),
+(
+  gen_random_uuid(),
+  (SELECT id FROM profiles LIMIT 1),
+  NULL,
+  'public',
+  'Banana Pancakes',
+  'Two-ingredient pancakes, naturally sweet and gluten-free.',
+  2, 5, 10,
+  $$[{"name":"ripe bananas","quantity":"2"},{"name":"eggs","quantity":"2"},{"name":"butter","quantity":"1 tsp"}]$$::jsonb,
+  $$[{"step":1,"instruction":"Mash the bananas in a bowl until smooth."},{"step":2,"instruction":"Beat in the eggs until fully combined."},{"step":3,"instruction":"Melt butter in a non-stick pan over medium heat."},{"step":4,"instruction":"Pour small rounds of batter into the pan. Cook for 2 minutes until bubbles form, then flip and cook for 1 minute more."},{"step":5,"instruction":"Serve with honey or fresh fruit."}]$$::jsonb,
+  ARRAY['breakfast','quick','gluten-free']
+),
+(
+  gen_random_uuid(),
+  (SELECT id FROM profiles LIMIT 1),
+  NULL,
+  'public',
+  'Chicken Caesar Salad',
+  'Crispy chicken over cos lettuce with a classic Caesar dressing.',
+  2, 15, 15,
+  $$[{"name":"chicken breasts","quantity":"2"},{"name":"cos lettuce","quantity":"1 head"},{"name":"parmesan","quantity":"40g"},{"name":"croutons","quantity":"handful"},{"name":"Caesar dressing","quantity":"4 tbsp"},{"name":"olive oil","quantity":"1 tbsp"},{"name":"salt and pepper","quantity":"to taste"}]$$::jsonb,
+  $$[{"step":1,"instruction":"Season chicken breasts with salt and pepper. Pan-fry in olive oil over medium-high heat for 6 to 7 minutes each side until cooked through."},{"step":2,"instruction":"Rest the chicken for 5 minutes, then slice."},{"step":3,"instruction":"Tear lettuce into a large bowl. Add croutons and most of the parmesan."},{"step":4,"instruction":"Drizzle over the Caesar dressing and toss to coat."},{"step":5,"instruction":"Top with sliced chicken and the remaining parmesan. Serve immediately."}]$$::jsonb,
+  ARRAY['salad','lunch','chicken']
+),
+(
+  gen_random_uuid(),
+  (SELECT id FROM profiles LIMIT 1),
+  NULL,
+  'public',
+  'Lemon Drizzle Cake',
+  'A light, zesty loaf cake with a crunchy sugar topping.',
+  8, 20, 35,
+  $$[{"name":"self-raising flour","quantity":"175g"},{"name":"caster sugar","quantity":"175g"},{"name":"unsalted butter, softened","quantity":"175g"},{"name":"eggs","quantity":"3"},{"name":"lemons (zest and juice)","quantity":"2"},{"name":"icing sugar","quantity":"85g"}]$$::jsonb,
+  $$[{"step":1,"instruction":"Preheat oven to 180C (160C fan). Grease and line a 900g loaf tin."},{"step":2,"instruction":"Beat together the butter and caster sugar until pale and fluffy."},{"step":3,"instruction":"Beat in the eggs one at a time, then fold in the flour and lemon zest."},{"step":4,"instruction":"Pour into the prepared tin and bake for 30 to 35 minutes until a skewer comes out clean."},{"step":5,"instruction":"Mix the lemon juice with the icing sugar to make the drizzle."},{"step":6,"instruction":"While the cake is still warm, poke holes across the top with a skewer and pour over the drizzle. Leave to cool in the tin."}]$$::jsonb,
+  ARRAY['baking','dessert','cake']
+);

--- a/src/app/recipes/[id]/edit/page.tsx
+++ b/src/app/recipes/[id]/edit/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState, type SubmitEvent } from 'react'
+import { use, useEffect, useState, type SubmitEvent } from 'react'
 
 import { useMutation, useQuery } from '@apollo/client/react'
 import Link from 'next/link'
@@ -8,10 +8,13 @@ import { useRouter } from 'next/navigation'
 
 import { useUserAndSession } from '@/components/session-provider'
 import {
-	GET_MY_HOUSEHOLD,
-	type MyHouseholdData,
-} from '@/lib/graphql/households'
-import { CREATE_RECIPE, type CreateRecipeResult } from '@/lib/graphql/recipes'
+	GET_RECIPE,
+	UPDATE_RECIPE,
+	type Ingredient,
+	type MethodStep,
+	type RecipeDetailData,
+	type UpdateRecipeResult,
+} from '@/lib/graphql/recipes'
 
 interface IngredientRow {
 	name: string
@@ -22,22 +25,26 @@ interface MethodRow {
 	instruction: string
 }
 
-export default function NewRecipePage() {
+export default function EditRecipePage({
+	params,
+}: {
+	params: Promise<{ id: string }>
+}) {
+	const { id } = use(params)
 	const router = useRouter()
 	const { user, isAuthenticated } = useUserAndSession()
 
-	const { data: householdData } = useQuery<MyHouseholdData>(GET_MY_HOUSEHOLD, {
-		variables: { userId: user?.id },
-		skip: !user?.id,
-	})
+	const {
+		data,
+		loading: queryLoading,
+		error: queryError,
+	} = useQuery<RecipeDetailData>(GET_RECIPE, { variables: { id } })
+	const recipe = data?.recipesCollection?.edges?.[0]?.node
 
-	const householdId =
-		householdData?.household_membersCollection?.edges?.[0]?.node
-			?.household_id ?? null
+	const [updateRecipe, { loading: mutationLoading, error }] =
+		useMutation<UpdateRecipeResult>(UPDATE_RECIPE)
 
-	const [createRecipe, { loading, error }] =
-		useMutation<CreateRecipeResult>(CREATE_RECIPE)
-
+	const [initialized, setInitialized] = useState(false)
 	const [title, setTitle] = useState('')
 	const [description, setDescription] = useState('')
 	const [servings, setServings] = useState('')
@@ -56,7 +63,56 @@ export default function NewRecipePage() {
 		}
 	}, [isAuthenticated, router])
 
+	useEffect(() => {
+		if (!recipe || initialized) return
+
+		if (user && recipe.created_by !== user.id) {
+			router.replace(`/recipes/${id}`)
+			return
+		}
+
+		setTitle(recipe.title)
+		setDescription(recipe.description ?? '')
+		setServings(recipe.servings ? String(recipe.servings) : '')
+		setPrepTime(recipe.prep_time ? String(recipe.prep_time) : '')
+		setCookTime(recipe.cook_time ? String(recipe.cook_time) : '')
+		setVisibility(recipe.visibility)
+		setTagsInput((recipe.tags ?? []).join(', '))
+
+		const parsedIngredients = JSON.parse(recipe.ingredients) as Ingredient[]
+		const parsedMethod = JSON.parse(recipe.method) as MethodStep[]
+
+		setIngredients(
+			parsedIngredients.length > 0
+				? parsedIngredients
+				: [{ name: '', quantity: '' }],
+		)
+		setMethod(
+			parsedMethod.length > 0
+				? parsedMethod.map((s) => ({ instruction: s.instruction }))
+				: [{ instruction: '' }],
+		)
+
+		setInitialized(true)
+	}, [recipe, initialized, user, id, router])
+
 	if (!isAuthenticated) return null
+
+	if (queryError) {
+		return (
+			<div className="p-4">
+				<p className="text-error">Recipe not found.</p>
+			</div>
+		)
+	}
+
+	if (queryLoading || !initialized) {
+		return (
+			<div className="p-4">
+				<span className="loading loading-spinner loading-md" />
+			</div>
+		)
+	}
 
 	const addIngredient = () =>
 		setIngredients((prev) => [...prev, { name: '', quantity: '' }])
@@ -92,10 +148,9 @@ export default function NewRecipePage() {
 			.filter((s) => s.instruction.trim())
 			.map((s, i) => ({ step: i + 1, instruction: s.instruction }))
 
-		const result = await createRecipe({
+		const result = await updateRecipe({
 			variables: {
-				created_by: user!.id,
-				household_id: householdId,
+				id,
 				visibility,
 				title,
 				description: description || null,
@@ -108,8 +163,8 @@ export default function NewRecipePage() {
 			},
 		})
 
-		const id = result.data?.insertIntorecipesCollection?.records?.[0]?.id
-		if (id) {
+		const updated = result.data?.updaterecipesCollection?.records?.[0]?.id
+		if (updated) {
 			router.push(`/recipes/${id}`)
 		} else {
 			router.push('/recipes')
@@ -118,11 +173,11 @@ export default function NewRecipePage() {
 
 	return (
 		<div className="p-4 space-y-6 max-w-2xl">
-			<Link href="/recipes" className="btn btn-ghost btn-sm pl-0">
+			<Link href={`/recipes/${id}`} className="btn btn-ghost btn-sm pl-0">
 				← Back
 			</Link>
 
-			<h1 className="text-2xl font-bold">New Recipe</h1>
+			<h1 className="text-2xl font-bold">Edit Recipe</h1>
 
 			<form onSubmit={(e) => void handleSubmit(e)} className="space-y-6">
 				<div className="form-control gap-1">
@@ -315,19 +370,19 @@ export default function NewRecipePage() {
 
 				{error && (
 					<p className="text-error text-sm">
-						Failed to save recipe. Please try again.
+						Failed to save changes. Please try again.
 					</p>
 				)}
 
 				<button
 					type="submit"
-					disabled={loading || !title.trim()}
+					disabled={mutationLoading || !title.trim()}
 					className="btn btn-primary w-full"
 				>
-					{loading ? (
+					{mutationLoading ? (
 						<span className="loading loading-spinner loading-sm" />
 					) : (
-						'Save Recipe'
+						'Save Changes'
 					)}
 				</button>
 			</form>

--- a/src/app/recipes/[id]/edit/page.tsx
+++ b/src/app/recipes/[id]/edit/page.tsx
@@ -8,8 +8,11 @@ import { useRouter } from 'next/navigation'
 
 import { useUserAndSession } from '@/components/session-provider'
 import {
+	DELETE_RECIPE,
+	GET_PUBLIC_RECIPES,
 	GET_RECIPE,
 	UPDATE_RECIPE,
+	type DeleteRecipeResult,
 	type Ingredient,
 	type MethodStep,
 	type RecipeDetailData,
@@ -43,6 +46,11 @@ export default function EditRecipePage({
 
 	const [updateRecipe, { loading: mutationLoading, error }] =
 		useMutation<UpdateRecipeResult>(UPDATE_RECIPE)
+
+	const [deleteRecipe, { loading: deleteLoading, error: deleteError }] =
+		useMutation<DeleteRecipeResult>(DELETE_RECIPE)
+
+	const [showDeleteModal, setShowDeleteModal] = useState(false)
 
 	const [initialized, setInitialized] = useState(false)
 	const [title, setTitle] = useState('')
@@ -135,6 +143,14 @@ export default function EditRecipePage({
 			prev.map((row, idx) => (idx === i ? { instruction: value } : row)),
 		)
 
+	const handleDelete = async () => {
+		await deleteRecipe({
+			variables: { id },
+			refetchQueries: [{ query: GET_PUBLIC_RECIPES }],
+		})
+		router.push('/recipes')
+	}
+
 	const handleSubmit = async (e: SubmitEvent<HTMLFormElement>) => {
 		e.preventDefault()
 
@@ -161,6 +177,10 @@ export default function EditRecipePage({
 				method: JSON.stringify(filteredMethod),
 				tags,
 			},
+			refetchQueries: [
+				{ query: GET_RECIPE, variables: { id } },
+				{ query: GET_PUBLIC_RECIPES },
+			],
 		})
 
 		const updated = result.data?.updaterecipesCollection?.records?.[0]?.id
@@ -385,7 +405,53 @@ export default function EditRecipePage({
 						'Save Changes'
 					)}
 				</button>
+				<div className="divider" />
+
+				<button
+					type="button"
+					onClick={() => setShowDeleteModal(true)}
+					className="btn btn-error btn-outline w-full"
+				>
+					Delete Recipe
+				</button>
 			</form>
+
+			{showDeleteModal && (
+				<div className="modal modal-open">
+					<div className="modal-box">
+						<h3 className="font-bold text-lg">Delete Recipe?</h3>
+						<p className="py-4 text-base-content/70">This cannot be undone.</p>
+						{deleteError && (
+							<p className="text-error text-sm mb-2">
+								Failed to delete. Please try again.
+							</p>
+						)}
+						<div className="modal-action">
+							<button
+								onClick={() => setShowDeleteModal(false)}
+								className="btn btn-ghost"
+							>
+								Cancel
+							</button>
+							<button
+								onClick={() => void handleDelete()}
+								disabled={deleteLoading}
+								className="btn btn-error"
+							>
+								{deleteLoading ? (
+									<span className="loading loading-spinner loading-sm" />
+								) : (
+									'Delete'
+								)}
+							</button>
+						</div>
+					</div>
+					<div
+						className="modal-backdrop"
+						onClick={() => setShowDeleteModal(false)}
+					/>
+				</div>
+			)}
 		</div>
 	)
 }

--- a/src/app/recipes/[id]/page.tsx
+++ b/src/app/recipes/[id]/page.tsx
@@ -24,6 +24,7 @@ export default function RecipePage({
 
 	const { data, loading, error } = useQuery<RecipeDetailData>(GET_RECIPE, {
 		variables: { id },
+		fetchPolicy: 'cache-and-network',
 	})
 	const recipe = data?.recipesCollection?.edges?.[0]?.node
 	const canEdit = !!user && recipe?.created_by === user.id

--- a/src/app/recipes/[id]/page.tsx
+++ b/src/app/recipes/[id]/page.tsx
@@ -5,6 +5,7 @@ import { use } from 'react'
 import { useQuery } from '@apollo/client/react'
 import Link from 'next/link'
 
+import { useUserAndSession } from '@/components/session-provider'
 import {
 	GET_RECIPE,
 	type Ingredient,
@@ -19,10 +20,14 @@ export default function RecipePage({
 }) {
 	const { id } = use(params)
 
+	const { user } = useUserAndSession()
+
 	const { data, loading, error } = useQuery<RecipeDetailData>(GET_RECIPE, {
 		variables: { id },
 	})
 	const recipe = data?.recipesCollection?.edges?.[0]?.node
+	const canEdit = !!user && recipe?.created_by === user.id
+	// 3RL.2 will also allow household leader/contributor
 
 	if (loading) {
 		return (
@@ -46,9 +51,16 @@ export default function RecipePage({
 
 	return (
 		<div className="p-4 space-y-6 max-w-2xl">
-			<Link href="/recipes" className="btn btn-ghost btn-sm pl-0">
-				← Back
-			</Link>
+			<div className="flex items-center justify-between">
+				<Link href="/recipes" className="btn btn-ghost btn-sm pl-0">
+					← Back
+				</Link>
+				{canEdit && (
+					<Link href={`/recipes/${id}/edit`} className="btn btn-outline btn-sm">
+						Edit
+					</Link>
+				)}
+			</div>
 
 			<div>
 				<h1 className="text-3xl font-bold">{recipe.title}</h1>

--- a/src/app/recipes/[id]/page.tsx
+++ b/src/app/recipes/[id]/page.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import { use } from 'react'
+
+import { useQuery } from '@apollo/client/react'
+import Link from 'next/link'
+
+import {
+	GET_RECIPE,
+	type Ingredient,
+	type MethodStep,
+	type RecipeDetailData,
+} from '@/lib/graphql/recipes'
+
+export default function RecipePage({
+	params,
+}: {
+	params: Promise<{ id: string }>
+}) {
+	const { id } = use(params)
+
+	const { data, loading, error } = useQuery<RecipeDetailData>(GET_RECIPE, {
+		variables: { id },
+	})
+	const recipe = data?.recipesCollection?.edges?.[0]?.node
+
+	if (loading) {
+		return (
+			<div className="p-4">
+				<span className="loading loading-spinner loading-md" />
+			</div>
+		)
+	}
+
+	if (error || !recipe) {
+		return (
+			<div className="p-4">
+				<p className="text-error">Recipe not found.</p>
+			</div>
+		)
+	}
+
+	const ingredients = JSON.parse(recipe.ingredients) as Ingredient[]
+	const method = JSON.parse(recipe.method) as MethodStep[]
+	const totalTime = (recipe.prep_time ?? 0) + (recipe.cook_time ?? 0)
+
+	return (
+		<div className="p-4 space-y-6 max-w-2xl">
+			<Link href="/recipes" className="btn btn-ghost btn-sm pl-0">
+				← Back
+			</Link>
+
+			<div>
+				<h1 className="text-3xl font-bold">{recipe.title}</h1>
+				{recipe.description && (
+					<p className="text-base-content/70 mt-1">{recipe.description}</p>
+				)}
+			</div>
+
+			<div className="flex gap-4 text-sm text-base-content/60 flex-wrap">
+				{recipe.servings && <span>{recipe.servings} servings</span>}
+				{recipe.prep_time && <span>Prep {recipe.prep_time} min</span>}
+				{recipe.cook_time && <span>Cook {recipe.cook_time} min</span>}
+				{totalTime > 0 && <span>Total {totalTime} min</span>}
+			</div>
+
+			{(recipe.tags ?? []).length > 0 && (
+				<div className="flex gap-1 flex-wrap">
+					{recipe.tags.map((t) => (
+						<span key={t} className="badge badge-outline">
+							{t}
+						</span>
+					))}
+				</div>
+			)}
+
+			<div>
+				<h2 className="text-xl font-semibold mb-3">Ingredients</h2>
+				<ul className="space-y-1">
+					{ingredients.map((ing, i) => (
+						<li key={i} className="flex gap-3">
+							<span className="text-base-content/60 min-w-24 shrink-0">
+								{ing.quantity}
+							</span>
+							<span>{ing.name}</span>
+						</li>
+					))}
+				</ul>
+			</div>
+
+			<div>
+				<h2 className="text-xl font-semibold mb-3">Method</h2>
+				<ol className="space-y-4">
+					{method.map((s) => (
+						<li key={s.step} className="flex gap-3">
+							<span className="font-bold text-primary shrink-0">{s.step}.</span>
+							<span>{s.instruction}</span>
+						</li>
+					))}
+				</ol>
+			</div>
+		</div>
+	)
+}

--- a/src/app/recipes/new/page.tsx
+++ b/src/app/recipes/new/page.tsx
@@ -1,0 +1,334 @@
+'use client'
+
+import { useEffect, useState, type SubmitEvent } from 'react'
+
+import { useMutation, useQuery } from '@apollo/client/react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+
+import { useUserAndSession } from '@/components/session-provider'
+import {
+	GET_MY_HOUSEHOLD,
+	type MyHouseholdData,
+} from '@/lib/graphql/households'
+import { CREATE_RECIPE, type CreateRecipeResult } from '@/lib/graphql/recipes'
+
+interface IngredientRow {
+	name: string
+	quantity: string
+}
+
+interface MethodRow {
+	instruction: string
+}
+
+export default function NewRecipePage() {
+	const router = useRouter()
+	const { user, isAuthenticated } = useUserAndSession()
+
+	const { data: householdData } = useQuery<MyHouseholdData>(GET_MY_HOUSEHOLD, {
+		variables: { userId: user?.id },
+		skip: !user?.id,
+	})
+
+	const householdId =
+		householdData?.household_membersCollection?.edges?.[0]?.node
+			?.household_id ?? null
+
+	const [createRecipe, { loading, error }] =
+		useMutation<CreateRecipeResult>(CREATE_RECIPE)
+
+	const [title, setTitle] = useState('')
+	const [description, setDescription] = useState('')
+	const [servings, setServings] = useState('')
+	const [prepTime, setPrepTime] = useState('')
+	const [cookTime, setCookTime] = useState('')
+	const [visibility, setVisibility] = useState<'private' | 'public'>('private')
+	const [tagsInput, setTagsInput] = useState('')
+	const [ingredients, setIngredients] = useState<IngredientRow[]>([
+		{ name: '', quantity: '' },
+	])
+	const [method, setMethod] = useState<MethodRow[]>([{ instruction: '' }])
+
+	useEffect(() => {
+		if (!isAuthenticated) {
+			router.replace('/auth/login')
+		}
+	}, [isAuthenticated, router])
+
+	if (!isAuthenticated) return null
+
+	const addIngredient = () =>
+		setIngredients((prev) => [...prev, { name: '', quantity: '' }])
+	const removeIngredient = (i: number) =>
+		setIngredients((prev) => prev.filter((_, idx) => idx !== i))
+	const updateIngredient = (
+		i: number,
+		field: keyof IngredientRow,
+		value: string,
+	) =>
+		setIngredients((prev) =>
+			prev.map((row, idx) => (idx === i ? { ...row, [field]: value } : row)),
+		)
+
+	const addStep = () => setMethod((prev) => [...prev, { instruction: '' }])
+	const removeStep = (i: number) =>
+		setMethod((prev) => prev.filter((_, idx) => idx !== i))
+	const updateStep = (i: number, value: string) =>
+		setMethod((prev) =>
+			prev.map((row, idx) => (idx === i ? { instruction: value } : row)),
+		)
+
+	const handleSubmit = async (e: SubmitEvent<HTMLFormElement>) => {
+		e.preventDefault()
+
+		const tags = tagsInput
+			.split(',')
+			.map((t) => t.trim())
+			.filter(Boolean)
+
+		const filteredIngredients = ingredients.filter((i) => i.name.trim())
+		const filteredMethod = method
+			.filter((s) => s.instruction.trim())
+			.map((s, i) => ({ step: i + 1, instruction: s.instruction }))
+
+		const result = await createRecipe({
+			variables: {
+				created_by: user!.id,
+				household_id: householdId,
+				visibility,
+				title,
+				description: description || null,
+				servings: servings ? parseInt(servings, 10) : null,
+				prep_time: prepTime ? parseInt(prepTime, 10) : null,
+				cook_time: cookTime ? parseInt(cookTime, 10) : null,
+				ingredients: JSON.stringify(filteredIngredients),
+				method: JSON.stringify(filteredMethod),
+				tags,
+			},
+		})
+
+		const id = result.data?.insertIntorecipesCollection?.records?.[0]?.id
+		if (id) {
+			router.push(`/recipes/${id}`)
+		}
+	}
+
+	return (
+		<div className="p-4 space-y-6 max-w-2xl">
+			<Link href="/recipes" className="btn btn-ghost btn-sm pl-0">
+				← Back
+			</Link>
+
+			<h1 className="text-2xl font-bold">New Recipe</h1>
+
+			<form onSubmit={(e) => void handleSubmit(e)} className="space-y-6">
+				<div className="form-control gap-1">
+					<label htmlFor="title" className="label-text font-medium">
+						Title *
+					</label>
+					<input
+						id="title"
+						type="text"
+						value={title}
+						onChange={(e) => setTitle(e.target.value)}
+						className="input input-bordered w-full"
+						required
+					/>
+				</div>
+
+				<div className="form-control gap-1">
+					<label htmlFor="description" className="label-text font-medium">
+						Description
+					</label>
+					<textarea
+						id="description"
+						value={description}
+						onChange={(e) => setDescription(e.target.value)}
+						className="textarea textarea-bordered w-full"
+						rows={2}
+					/>
+				</div>
+
+				<div className="grid grid-cols-3 gap-3">
+					<div className="form-control gap-1">
+						<label htmlFor="servings" className="label-text font-medium">
+							Servings
+						</label>
+						<input
+							id="servings"
+							type="number"
+							min="1"
+							value={servings}
+							onChange={(e) => setServings(e.target.value)}
+							className="input input-bordered"
+						/>
+					</div>
+					<div className="form-control gap-1">
+						<label htmlFor="prep-time" className="label-text font-medium">
+							Prep (min)
+						</label>
+						<input
+							id="prep-time"
+							type="number"
+							min="0"
+							value={prepTime}
+							onChange={(e) => setPrepTime(e.target.value)}
+							className="input input-bordered"
+						/>
+					</div>
+					<div className="form-control gap-1">
+						<label htmlFor="cook-time" className="label-text font-medium">
+							Cook (min)
+						</label>
+						<input
+							id="cook-time"
+							type="number"
+							min="0"
+							value={cookTime}
+							onChange={(e) => setCookTime(e.target.value)}
+							className="input input-bordered"
+						/>
+					</div>
+				</div>
+
+				<div className="form-control gap-1">
+					<label htmlFor="tags" className="label-text font-medium">
+						Tags
+					</label>
+					<input
+						id="tags"
+						type="text"
+						placeholder="pasta, italian, dinner"
+						value={tagsInput}
+						onChange={(e) => setTagsInput(e.target.value)}
+						className="input input-bordered w-full"
+					/>
+					<span className="label-text-alt text-base-content/60">
+						Comma-separated
+					</span>
+				</div>
+
+				<div className="form-control gap-2">
+					<span className="label-text font-medium">Visibility</span>
+					<div className="flex gap-6">
+						<label className="flex items-center gap-2 cursor-pointer">
+							<input
+								type="radio"
+								name="visibility"
+								value="private"
+								checked={visibility === 'private'}
+								onChange={() => setVisibility('private')}
+								className="radio radio-sm"
+							/>
+							<span className="text-sm">Private</span>
+						</label>
+						<label className="flex items-center gap-2 cursor-pointer">
+							<input
+								type="radio"
+								name="visibility"
+								value="public"
+								checked={visibility === 'public'}
+								onChange={() => setVisibility('public')}
+								className="radio radio-sm"
+							/>
+							<span className="text-sm">Public</span>
+						</label>
+					</div>
+				</div>
+
+				<div className="space-y-2">
+					<h2 className="text-lg font-semibold">Ingredients</h2>
+					{ingredients.map((ing, i) => (
+						<div key={i} className="flex gap-2 items-center">
+							<input
+								type="text"
+								placeholder="Quantity"
+								value={ing.quantity}
+								onChange={(e) =>
+									updateIngredient(i, 'quantity', e.target.value)
+								}
+								className="input input-bordered input-sm w-28 shrink-0"
+							/>
+							<input
+								type="text"
+								placeholder="Ingredient"
+								value={ing.name}
+								onChange={(e) => updateIngredient(i, 'name', e.target.value)}
+								className="input input-bordered input-sm flex-1"
+							/>
+							{ingredients.length > 1 && (
+								<button
+									type="button"
+									onClick={() => removeIngredient(i)}
+									className="btn btn-ghost btn-sm btn-square text-error"
+								>
+									✕
+								</button>
+							)}
+						</div>
+					))}
+					<button
+						type="button"
+						onClick={addIngredient}
+						className="btn btn-ghost btn-sm"
+					>
+						+ Add ingredient
+					</button>
+				</div>
+
+				<div className="space-y-2">
+					<h2 className="text-lg font-semibold">Method</h2>
+					{method.map((step, i) => (
+						<div key={i} className="flex gap-2 items-start">
+							<span className="font-bold text-primary pt-2 shrink-0 w-5">
+								{i + 1}.
+							</span>
+							<textarea
+								placeholder="Step instruction..."
+								value={step.instruction}
+								onChange={(e) => updateStep(i, e.target.value)}
+								className="textarea textarea-bordered textarea-sm flex-1"
+								rows={2}
+							/>
+							{method.length > 1 && (
+								<button
+									type="button"
+									onClick={() => removeStep(i)}
+									className="btn btn-ghost btn-sm btn-square text-error mt-1"
+								>
+									✕
+								</button>
+							)}
+						</div>
+					))}
+					<button
+						type="button"
+						onClick={addStep}
+						className="btn btn-ghost btn-sm"
+					>
+						+ Add step
+					</button>
+				</div>
+
+				{error && (
+					<p className="text-error text-sm">
+						Failed to save recipe. Please try again.
+					</p>
+				)}
+
+				<button
+					type="submit"
+					disabled={loading || !title.trim()}
+					className="btn btn-primary w-full"
+				>
+					{loading ? (
+						<span className="loading loading-spinner loading-sm" />
+					) : (
+						'Save Recipe'
+					)}
+				</button>
+			</form>
+		</div>
+	)
+}

--- a/src/app/recipes/new/page.tsx
+++ b/src/app/recipes/new/page.tsx
@@ -11,7 +11,11 @@ import {
 	GET_MY_HOUSEHOLD,
 	type MyHouseholdData,
 } from '@/lib/graphql/households'
-import { CREATE_RECIPE, type CreateRecipeResult } from '@/lib/graphql/recipes'
+import {
+	CREATE_RECIPE,
+	GET_PUBLIC_RECIPES,
+	type CreateRecipeResult,
+} from '@/lib/graphql/recipes'
 
 interface IngredientRow {
 	name: string
@@ -106,6 +110,7 @@ export default function NewRecipePage() {
 				method: JSON.stringify(filteredMethod),
 				tags,
 			},
+			refetchQueries: [{ query: GET_PUBLIC_RECIPES }],
 		})
 
 		const id = result.data?.insertIntorecipesCollection?.records?.[0]?.id

--- a/src/app/recipes/page.tsx
+++ b/src/app/recipes/page.tsx
@@ -19,9 +19,11 @@ export default function RecipesPage() {
 
 	const { data, loading, error } = useQuery<RecipesCollectionData>(
 		GET_PUBLIC_RECIPES,
-		{ skip: activeTab !== 'explore' },
+		{
+			skip: activeTab !== 'explore',
+			fetchPolicy: 'cache-and-network',
+		},
 	)
-
 	const recipes = data?.recipesCollection?.edges?.map((e) => e.node) ?? []
 	const tags = Array.from(new Set(recipes.flatMap((r) => r.tags ?? [])))
 

--- a/src/app/recipes/page.tsx
+++ b/src/app/recipes/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 
 import { useQuery } from '@apollo/client/react'
+import Link from 'next/link'
 
 import {
 	GET_PUBLIC_RECIPES,
@@ -97,9 +98,12 @@ export default function RecipesPage() {
 													))}
 												</div>
 											)}
-											<button className="btn btn-sm btn-accent mt-2">
+											<Link
+												href={`/recipes/${recipe.id}`}
+												className="btn btn-sm btn-accent mt-2"
+											>
 												View
-											</button>
+											</Link>
 										</div>
 									</div>
 								))}

--- a/src/app/recipes/page.tsx
+++ b/src/app/recipes/page.tsx
@@ -2,6 +2,13 @@
 
 import { useState } from 'react'
 
+import { useQuery } from '@apollo/client/react'
+
+import {
+	GET_PUBLIC_RECIPES,
+	type RecipesCollectionData,
+} from '@/lib/graphql/recipes'
+
 export default function RecipesPage() {
 	const [search, setSearch] = useState('')
 	const [activeTag, setActiveTag] = useState<string | null>(null)
@@ -9,17 +16,17 @@ export default function RecipesPage() {
 		'explore',
 	)
 
-	const recipes = [
-		{ id: 1, title: 'Spaghetti Bolognese', tags: ['pasta', 'beef'] },
-		{ id: 2, title: 'Avocado Toast', tags: ['vegan', 'breakfast'] },
-		{ id: 3, title: 'Chicken Curry', tags: ['spicy', 'chicken'] },
-	]
+	const { data, loading, error } = useQuery<RecipesCollectionData>(
+		GET_PUBLIC_RECIPES,
+		{ skip: activeTab !== 'explore' },
+	)
 
-	const tags = ['pasta', 'beef', 'vegan', 'breakfast', 'spicy', 'chicken']
+	const recipes = data?.recipesCollection?.edges?.map((e) => e.node) ?? []
+	const tags = Array.from(new Set(recipes.flatMap((r) => r.tags ?? [])))
 
 	const filteredRecipes = recipes.filter((r) => {
 		const matchesSearch = r.title.toLowerCase().includes(search.toLowerCase())
-		const matchesTag = activeTag ? r.tags.includes(activeTag) : true
+		const matchesTag = activeTag ? (r.tags ?? []).includes(activeTag) : true
 		return matchesSearch && matchesTag
 	})
 
@@ -35,19 +42,21 @@ export default function RecipesPage() {
 				className="input input-bordered w-full"
 			/>
 
-			<div className="flex flex-wrap gap-2">
-				{tags.map((tag) => (
-					<button
-						key={tag}
-						className={`badge cursor-pointer ${
-							activeTag === tag ? 'badge-primary' : 'badge-accent'
-						}`}
-						onClick={() => setActiveTag(activeTag === tag ? null : tag)}
-					>
-						{tag}
-					</button>
-				))}
-			</div>
+			{tags.length > 0 && (
+				<div className="flex flex-wrap gap-2">
+					{tags.map((tag) => (
+						<button
+							key={tag}
+							className={`badge cursor-pointer ${
+								activeTag === tag ? 'badge-primary' : 'badge-accent'
+							}`}
+							onClick={() => setActiveTag(activeTag === tag ? null : tag)}
+						>
+							{tag}
+						</button>
+					))}
+				</div>
+			)}
 
 			<div role="tablist" className="tabs tabs-bordered">
 				<button
@@ -68,27 +77,44 @@ export default function RecipesPage() {
 
 			<div className="mt-4">
 				{activeTab === 'explore' && (
-					<div className="grid gap-4">
-						{filteredRecipes.map((recipe) => (
-							<div key={recipe.id} className="card bg-base-100 shadow-md">
-								<div className="card-body">
-									<h2 className="card-title">{recipe.title}</h2>
-									<div className="flex gap-1">
-										{recipe.tags.map((t) => (
-											<span key={t} className="badge badge-outline">
-												{t}
-											</span>
-										))}
-									</div>
-									<button className="btn btn-sm btn-accent mt-2">View</button>
-								</div>
-							</div>
-						))}
-
-						{filteredRecipes.length === 0 && (
-							<p className="text-info">No recipes found.</p>
+					<>
+						{loading && <span className="loading loading-spinner loading-md" />}
+						{error && (
+							<p className="text-error text-sm">Failed to load recipes.</p>
 						)}
-					</div>
+						{!loading && !error && (
+							<div className="grid gap-4">
+								{filteredRecipes.map((recipe) => (
+									<div key={recipe.id} className="card bg-base-100 shadow-md">
+										<div className="card-body">
+											<h2 className="card-title">{recipe.title}</h2>
+											{(recipe.tags ?? []).length > 0 && (
+												<div className="flex gap-1 flex-wrap">
+													{recipe.tags.map((t) => (
+														<span key={t} className="badge badge-outline">
+															{t}
+														</span>
+													))}
+												</div>
+											)}
+											<button className="btn btn-sm btn-accent mt-2">
+												View
+											</button>
+										</div>
+									</div>
+								))}
+								{filteredRecipes.length === 0 && (
+									<p className="text-base-content/60">No public recipes yet.</p>
+								)}
+							</div>
+						)}
+					</>
+				)}
+
+				{activeTab === 'my-recipes' && (
+					<p className="text-base-content/60">
+						Join or create a household to see your recipes.
+					</p>
 				)}
 			</div>
 		</div>

--- a/src/app/recipes/page.tsx
+++ b/src/app/recipes/page.tsx
@@ -59,21 +59,29 @@ export default function RecipesPage() {
 				</div>
 			)}
 
-			<div role="tablist" className="tabs tabs-bordered">
-				<button
-					role="tab"
-					className={`tab ${activeTab === 'explore' ? 'tab-active' : ''}`}
-					onClick={() => setActiveTab('explore')}
+			<div className="flex items-center justify-between">
+				<div role="tablist" className="tabs tabs-bordered">
+					<button
+						role="tab"
+						className={`tab ${activeTab === 'explore' ? 'tab-active' : ''}`}
+						onClick={() => setActiveTab('explore')}
+					>
+						Explore
+					</button>
+					<button
+						role="tab"
+						className={`tab ${activeTab === 'my-recipes' ? 'tab-active' : ''}`}
+						onClick={() => setActiveTab('my-recipes')}
+					>
+						My Recipes
+					</button>
+				</div>
+				<Link
+					href="/recipes/new"
+					className="btn btn-sm btn-primary hidden md:inline-flex"
 				>
-					Explore
-				</button>
-				<button
-					role="tab"
-					className={`tab ${activeTab === 'my-recipes' ? 'tab-active' : ''}`}
-					onClick={() => setActiveTab('my-recipes')}
-				>
-					My Recipes
-				</button>
+					New Recipe
+				</Link>
 			</div>
 
 			<div className="mt-4">
@@ -121,6 +129,26 @@ export default function RecipesPage() {
 					</p>
 				)}
 			</div>
+
+			<Link
+				href="/recipes/new"
+				className="btn btn-primary btn-circle fixed bottom-20 right-4 shadow-lg md:hidden"
+			>
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					className="size-6"
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke="currentColor"
+					strokeWidth={2.5}
+				>
+					<path
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						d="M12 4v16m8-8H4"
+					/>
+				</svg>
+			</Link>
 		</div>
 	)
 }

--- a/src/lib/graphql/households.ts
+++ b/src/lib/graphql/households.ts
@@ -1,0 +1,23 @@
+import { gql } from '@apollo/client'
+
+export interface MyHouseholdNode {
+	household_id: string
+}
+
+export interface MyHouseholdData {
+	household_membersCollection: {
+		edges: Array<{ node: MyHouseholdNode }>
+	}
+}
+
+export const GET_MY_HOUSEHOLD = gql`
+	query GetMyHousehold($userId: UUID!) {
+		household_membersCollection(filter: { user_id: { eq: $userId } }) {
+			edges {
+				node {
+					household_id
+				}
+			}
+		}
+	}
+`

--- a/src/lib/graphql/recipes.ts
+++ b/src/lib/graphql/recipes.ts
@@ -50,6 +50,8 @@ export interface RecipeDetail {
 	ingredients: string
 	method: string
 	tags: string[]
+	created_by: string
+	visibility: 'private' | 'public'
 }
 
 export interface RecipeDetailData {
@@ -72,6 +74,8 @@ export const GET_RECIPE = gql`
 					ingredients
 					method
 					tags
+					created_by
+					visibility
 				}
 			}
 		}
@@ -114,6 +118,46 @@ export const CREATE_RECIPE = gql`
 					tags: $tags
 				}
 			]
+		) {
+			records {
+				id
+			}
+		}
+	}
+`
+
+export interface UpdateRecipeResult {
+	updaterecipesCollection: {
+		records: Array<{ id: string }>
+	}
+}
+
+export const UPDATE_RECIPE = gql`
+	mutation UpdateRecipe(
+		$id: UUID!
+		$visibility: visibility_type!
+		$title: String!
+		$description: String
+		$servings: Int
+		$prep_time: Int
+		$cook_time: Int
+		$ingredients: JSON!
+		$method: JSON!
+		$tags: [String!]!
+	) {
+		updaterecipesCollection(
+			filter: { id: { eq: $id } }
+			set: {
+				visibility: $visibility
+				title: $title
+				description: $description
+				servings: $servings
+				prep_time: $prep_time
+				cook_time: $cook_time
+				ingredients: $ingredients
+				method: $method
+				tags: $tags
+			}
 		) {
 			records {
 				id

--- a/src/lib/graphql/recipes.ts
+++ b/src/lib/graphql/recipes.ts
@@ -1,0 +1,54 @@
+import { gql } from '@apollo/client'
+
+export interface RecipeNode {
+	id: string
+	title: string
+	description: string | null
+	servings: number | null
+	tags: string[]
+}
+
+export interface RecipesCollectionData {
+	recipesCollection: {
+		edges: Array<{ node: RecipeNode }>
+	}
+}
+
+export const GET_PUBLIC_RECIPES = gql`
+	query GetPublicRecipes {
+		recipesCollection(filter: { visibility: { eq: public } }) {
+			edges {
+				node {
+					id
+					title
+					description
+					servings
+					tags
+				}
+			}
+		}
+	}
+`
+
+export const GET_MY_RECIPES = gql`
+	query GetMyRecipes($householdId: UUID, $userId: UUID!) {
+		recipesCollection(
+			filter: {
+				or: [
+					{ householdId: { eq: $householdId } }
+					{ createdBy: { eq: $userId } }
+				]
+			}
+		) {
+			edges {
+				node {
+					id
+					title
+					description
+					servings
+					tags
+				}
+			}
+		}
+	}
+`

--- a/src/lib/graphql/recipes.ts
+++ b/src/lib/graphql/recipes.ts
@@ -78,6 +78,50 @@ export const GET_RECIPE = gql`
 	}
 `
 
+export interface CreateRecipeResult {
+	insertIntorecipesCollection: {
+		records: Array<{ id: string }>
+	}
+}
+
+export const CREATE_RECIPE = gql`
+	mutation CreateRecipe(
+		$created_by: UUID!
+		$household_id: UUID
+		$visibility: visibility_type!
+		$title: String!
+		$description: String
+		$servings: Int
+		$prep_time: Int
+		$cook_time: Int
+		$ingredients: JSON!
+		$method: JSON!
+		$tags: [String!]!
+	) {
+		insertIntorecipesCollection(
+			objects: [
+				{
+					created_by: $created_by
+					household_id: $household_id
+					visibility: $visibility
+					title: $title
+					description: $description
+					servings: $servings
+					prep_time: $prep_time
+					cook_time: $cook_time
+					ingredients: $ingredients
+					method: $method
+					tags: $tags
+				}
+			]
+		) {
+			records {
+				id
+			}
+		}
+	}
+`
+
 export const GET_MY_RECIPES = gql`
 	query GetMyRecipes($householdId: UUID, $userId: UUID!) {
 		recipesCollection(

--- a/src/lib/graphql/recipes.ts
+++ b/src/lib/graphql/recipes.ts
@@ -30,6 +30,54 @@ export const GET_PUBLIC_RECIPES = gql`
 	}
 `
 
+export interface Ingredient {
+	name: string
+	quantity: string
+}
+
+export interface MethodStep {
+	step: number
+	instruction: string
+}
+
+export interface RecipeDetail {
+	id: string
+	title: string
+	description: string | null
+	servings: number | null
+	prep_time: number | null
+	cook_time: number | null
+	ingredients: string
+	method: string
+	tags: string[]
+}
+
+export interface RecipeDetailData {
+	recipesCollection: {
+		edges: Array<{ node: RecipeDetail }>
+	}
+}
+
+export const GET_RECIPE = gql`
+	query GetRecipe($id: UUID!) {
+		recipesCollection(filter: { id: { eq: $id } }) {
+			edges {
+				node {
+					id
+					title
+					description
+					servings
+					prep_time
+					cook_time
+					ingredients
+					method
+					tags
+				}
+			}
+		}
+	}
+`
+
 export const GET_MY_RECIPES = gql`
 	query GetMyRecipes($householdId: UUID, $userId: UUID!) {
 		recipesCollection(

--- a/src/lib/graphql/recipes.ts
+++ b/src/lib/graphql/recipes.ts
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/client'
+import { gql, type DocumentNode } from '@apollo/client'
 
 export interface RecipeNode {
 	id: string
@@ -159,6 +159,22 @@ export const UPDATE_RECIPE = gql`
 				tags: $tags
 			}
 		) {
+			records {
+				id
+			}
+		}
+	}
+`
+
+export interface DeleteRecipeResult {
+	deleteFromrecipesCollection: {
+		records: Array<{ id: string }>
+	}
+}
+
+export const DELETE_RECIPE: DocumentNode = gql`
+	mutation DeleteRecipe($id: UUID!) {
+		deleteFromrecipesCollection(filter: { id: { eq: $id } }) {
 			records {
 				id
 			}


### PR DESCRIPTION
# Full Recipe CRUD — Browse, View, Create, Edit & Delete

## Overview

Completes Milestone 2. Users can now browse public recipes, view full recipe details, create new recipes, edit their own, and delete them — all connected to Supabase via GraphQL.

> [!TIP]
> **After pulling:** Check your Supabase RLS policies on the `recipes` table. Two policy fixes are required for edit and delete to work correctly:
> 1. Add `OR (created_by = auth.uid())` to the `USING` clause of the write policy — without it, editing/deleting recipes with no household silently fails
> 2. Add a `FOR DELETE` policy: `USING (created_by = auth.uid())`

## Changes

<details>
<summary><strong>GraphQL — queries & mutations</strong></summary>

- `GET_PUBLIC_RECIPES`, `GET_RECIPE`, `GET_MY_RECIPES` queries
- `CREATE_RECIPE`, `UPDATE_RECIPE`, `DELETE_RECIPE` mutations
- `RecipeDetail` extended with `created_by` and `visibility` fields
- `DocumentNode` annotation on `DELETE_RECIPE` to satisfy ESLint `no-unsafe-argument`

</details>

<details>
<summary><strong>Recipe pages</strong></summary>

- **Browse** (`/recipes`) — live public recipes with search and tag filtering; `cache-and-network` to prevent stale list
- **Detail** (`/recipes/[id]`) — full recipe view with ingredients and method; edit button visible to creator only; `cache-and-network`
- **Create** (`/recipes/new`) — full form with dynamic ingredients and method steps; `refetchQueries` on submit
- **Edit** (`/recipes/[id]/edit`) — pre-filled form; permission guard redirects non-owners; `refetchQueries` on save
- **Delete** — confirmation modal on edit page; `refetchQueries` on confirm; redirects to `/recipes`

</details>

<details>
<summary><strong>Apollo cache management</strong></summary>

- `fetchPolicy: 'cache-and-network'` on browse and detail queries
- `refetchQueries` on all three mutations to keep the browse list and detail cache consistent after any change

</details>

<details>
<summary><strong>Dev tooling</strong></summary>

- Seed SQL (`scripts/seed.sql`) with 4 public recipes for local development

</details>

---

## Summary

This PR is like hiring a full kitchen brigade: before, you could stare at the menu (browse), maybe read a description (detail), but couldn't actually order anything. Now there's a chef to create dishes, a sous chef to tweak them, and a very firm maitre d' who'll confirm before throwing anything in the bin — and critically, the specials board actually updates when something new comes out of the kitchen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)