### PR TITLE
chore(config): disable service worker outside production, use webpack…

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -11,7 +11,7 @@ const nextConfig: NextConfig = {}
 const withSerwist = withSerwistInit({
 	swSrc: "src/sw.ts",
 	swDest: "public/sw.js",
-  	disable: process.env.NODE_ENV === "development",
+  	disable: process.env.NODE_ENV !== "production",
 	additionalPrecacheEntries: [{ url: "/~offline", revision }],
 })
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"scripts": {
 		"dev": "next dev --webpack",
-		"build": "next build",
+		"build": "next build --webpack",
 		"start": "next start",
 		"lint": "eslint src",
 		"lint-fix": "eslint src --fix",

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -111,6 +111,8 @@ export function Nav() {
 							unoptimized
 							loading="eager"
 							className="object-cover object-center scale-[1.12]"
+							priority
+							aria-hidden="true"
 						/>
 					</div>
 				</div>


### PR DESCRIPTION
# Pull Request

## 📋 Summary

- Serwist disabled when NODE_ENV !== "production" (was only "development"), ensuring it's off in test/CI environments too
- Add --webpack flag to build script for consistency with dev
- Add priority and aria-hidden to nav logo image

## 🔍 Motivation and Context

Getting ready to go live and therefore ensuring production elements are working. In addition work has been done to ensure the build is relatively fast, the logo image being a pain point. 

## 🛠 Changes

- Logo image has priority added to ensure faster load times. 
- Serwist disabled is changed so it will be disabled in everything other than production builds. 
- Webpack flag added to build to ensure consistency with dev and smooth build on vercel. 
