### PR TITLE
Security fixes

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -6,12 +6,13 @@ export async function GET(request: NextRequest) {
 	const { searchParams, origin } = new URL(request.url)
 	const code = searchParams.get('code')
 	const next = searchParams.get('next') ?? '/'
+	const safePath = next.startsWith('/') && !next.startsWith('//') ? next : '/'
 
 	if (code) {
 		const supabase = await serverClient()
 		const { error } = await supabase.auth.exchangeCodeForSession(code)
 		if (!error) {
-			return NextResponse.redirect(new URL(next, origin))
+			return NextResponse.redirect(new URL(safePath, origin))
 		}
 	}
 

--- a/src/app/auth/forgot-password/actions.ts
+++ b/src/app/auth/forgot-password/actions.ts
@@ -11,7 +11,8 @@ export async function requestPasswordReset(
 	if (!email) return { error: 'Email is required.', sent: false }
 
 	const supabase = await serverClient()
-	const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000'
+	const siteUrl = process.env.NEXT_PUBLIC_SITE_URL
+	if (!siteUrl) throw new Error('NEXT_PUBLIC_SITE_URL is not configured')
 
 	await supabase.auth.resetPasswordForEmail(email, {
 		redirectTo: `${siteUrl}/auth/callback?next=/auth/reset-password`,

--- a/src/app/auth/reset-password/actions.ts
+++ b/src/app/auth/reset-password/actions.ts
@@ -16,6 +16,14 @@ export async function resetPassword(
 		return { error: 'Password must be at least 8 characters.' }
 
 	const supabase = await serverClient()
+
+	const { data: { session } } = await supabase.auth.getSession()
+	const isRecoverySession = session?.amr?.some(m => m.method === 'recovery') ?? false
+
+	if (!isRecoverySession) {
+		return { error: 'Password reset link has expired. Please request a new one.' }
+	}
+
 	const { error } = await supabase.auth.updateUser({ password })
 
 	if (error) return { error: error.message }

--- a/src/app/auth/reset-password/actions.ts
+++ b/src/app/auth/reset-password/actions.ts
@@ -17,11 +17,22 @@ export async function resetPassword(
 
 	const supabase = await serverClient()
 
-	const { data: { session } } = await supabase.auth.getSession()
-	const isRecoverySession = session?.amr?.some(m => m.method === 'recovery') ?? false
+	const {
+		data: { session },
+	} = await supabase.auth.getSession()
+	const payload = session
+		? JSON.parse(
+				Buffer.from(session.access_token.split('.')[1], 'base64').toString(),
+			)
+		: null
+	const isRecoverySession =
+		Array.isArray(payload?.amr) &&
+		payload.amr.some((m: { method: string }) => m.method === 'recovery')
 
 	if (!isRecoverySession) {
-		return { error: 'Password reset link has expired. Please request a new one.' }
+		return {
+			error: 'Password reset link has expired. Please request a new one.',
+		}
 	}
 
 	const { error } = await supabase.auth.updateUser({ password })


### PR DESCRIPTION
- Prevent open redirect in callback route by validating `next` is a root-relative path before passing it to new URL()
- Guard password reset action behind AMR recovery check so only sessions originating from a reset link can call updateUser()
- Remove localhost fallback for NEXT_PUBLIC_SITE_URL; throw if unset so misconfiguration fails loudly rather than silently misdirecting reset links

# Pull Request

## 📋 Summary

- Prevent open redirect in callback route by validating `next` is a root-relative path before passing it to new URL()
- Guard password reset action behind AMR recovery check so only sessions originating from a reset link can call updateUser()
- Remove localhost fallback for NEXT_PUBLIC_SITE_URL; throw if unset so misconfiguration fails loudly rather than silently misdirecting reset links


