### PR TITLE
Add Automated Test Suite (90 Tests)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 20
           cache: 'npm'
       - run: npm ci
       - run: npm run lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
-      - run: npm ci
+      - run: npm install
       - run: npm run lint

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
-      - run: npm ci
+      - run: npm install
       - run: npm run types

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 20
           cache: 'npm'
       - run: npm ci
       - run: npm run types

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -103,4 +103,17 @@ export default tseslint.config(
 			'prettier/prettier': 'error',
 		},
 	},
+
+	// Test files — relax rules that conflict with Vitest patterns
+	{
+		name: 'test-overrides',
+		files: ['src/**/*.test.{ts,tsx}'],
+		rules: {
+			// Mocks require partial types — `any` is unavoidable
+			'@typescript-eslint/no-explicit-any': 'off',
+			// vi.mock() must use `vi` before other imports are resolved,
+			// which breaks alphabetical ordering enforced by import/order
+			'import/order': 'off',
+		},
+	},
 )

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
 				"@types/node": "^20",
 				"@types/react": "19.2.14",
 				"@types/react-dom": "19.2.3",
+				"@vitest/coverage-v8": "^4.1.9",
 				"cssnano": "^7.1.0",
 				"daisyui": "^5.0.50",
 				"eslint": "^9",
@@ -41,7 +42,8 @@
 				"eslint-plugin-react-hooks": "^5.2.0",
 				"tailwindcss": "^4",
 				"typescript": "^5",
-				"typescript-eslint": "^8.40.0"
+				"typescript-eslint": "^8.40.0",
+				"vitest": "^4.1.9"
 			}
 		},
 		"node_modules/@ai-sdk/anthropic": {
@@ -459,6 +461,16 @@
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/@bcoe/v8-coverage": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+			"integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@colordx/core": {
 			"version": "5.4.3",
 			"resolved": "https://registry.npmjs.org/@colordx/core/-/core-5.4.3.tgz",
@@ -466,32 +478,10 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@emnapi/core": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@emnapi/wasi-threads": "1.2.1",
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@emnapi/runtime": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
-			}
-		},
 		"node_modules/@emnapi/wasi-threads": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-			"integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+			"integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -1448,6 +1438,16 @@
 				"node": ">=8.0.0"
 			}
 		},
+		"node_modules/@oxc-project/types": {
+			"version": "0.138.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
+			"integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			}
+		},
 		"node_modules/@pkgr/core": {
 			"version": "0.2.9",
 			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
@@ -1460,6 +1460,289 @@
 			"funding": {
 				"url": "https://opencollective.com/pkgr"
 			}
+		},
+		"node_modules/@rolldown/binding-android-arm64": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
+			"integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-darwin-arm64": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
+			"integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-darwin-x64": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
+			"integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-freebsd-x64": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
+			"integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
+			"integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm64-gnu": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
+			"integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm64-musl": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
+			"integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
+			"integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-s390x-gnu": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
+			"integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-x64-gnu": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
+			"integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-x64-musl": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
+			"integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-openharmony-arm64": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
+			"integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
+			"integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "1.11.1",
+				"@emnapi/runtime": "1.11.1",
+				"@napi-rs/wasm-runtime": "^1.1.6"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+			"integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@tybys/wasm-util": "^0.10.3"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
+			"peerDependencies": {
+				"@emnapi/core": "^1.7.1",
+				"@emnapi/runtime": "^1.7.1"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-arm64-msvc": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
+			"integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-x64-msvc": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
+			"integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/pluginutils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+			"integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@rtsao/scc": {
 			"version": "1.1.0",
@@ -1999,14 +2282,25 @@
 			}
 		},
 		"node_modules/@tybys/wasm-util": {
-			"version": "0.10.2",
-			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-			"integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+			"integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@types/chai": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*",
+				"assertion-error": "^2.0.1"
 			}
 		},
 		"node_modules/@types/debug": {
@@ -2017,6 +2311,13 @@
 			"dependencies": {
 				"@types/ms": "*"
 			}
+		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/estree": {
 			"version": "1.0.9",
@@ -2077,6 +2378,7 @@
 			"integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
@@ -2680,6 +2982,151 @@
 				"node": ">= 20"
 			}
 		},
+		"node_modules/@vitest/coverage-v8": {
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+			"integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@bcoe/v8-coverage": "^1.0.2",
+				"@vitest/utils": "4.1.9",
+				"ast-v8-to-istanbul": "^1.0.0",
+				"istanbul-lib-coverage": "^3.2.2",
+				"istanbul-lib-report": "^3.0.1",
+				"istanbul-reports": "^3.2.0",
+				"magicast": "^0.5.2",
+				"obug": "^2.1.1",
+				"std-env": "^4.0.0-rc.1",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@vitest/browser": "4.1.9",
+				"vitest": "4.1.9"
+			},
+			"peerDependenciesMeta": {
+				"@vitest/browser": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/expect": {
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+			"integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.1.9",
+				"@vitest/utils": "4.1.9",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+			"integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.9",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+			"integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+			"integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.9",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+			"integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.9",
+				"@vitest/utils": "4.1.9",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+			"integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+			"integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.9",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
 		"node_modules/@wry/caches": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@wry/caches/-/caches-1.0.1.tgz",
@@ -2989,10 +3436,39 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/ast-types-flow": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
 			"integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/ast-v8-to-istanbul": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+			"integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.31",
+				"estree-walker": "^3.0.3",
+				"js-tokens": "^10.0.0"
+			}
+		},
+		"node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+			"integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3237,6 +3713,16 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/chai": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/chalk": {
@@ -4004,6 +4490,13 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/es-module-lexer": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+			"integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/es-object-atoms": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -4558,6 +5051,16 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4575,6 +5078,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+			"integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/extend": {
@@ -4729,6 +5242,21 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/function-bind": {
@@ -5153,6 +5681,13 @@
 			"dependencies": {
 				"hermes-estree": "0.25.1"
 			}
+		},
+		"node_modules/html-escaper": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/html-url-attributes": {
 			"version": "3.0.1",
@@ -5715,6 +6250,45 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/istanbul-lib-coverage": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+			"integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/istanbul-lib-report": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+			"integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"istanbul-lib-coverage": "^3.0.0",
+				"make-dir": "^4.0.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-reports": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+			"integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"html-escaper": "^2.0.0",
+				"istanbul-lib-report": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/iterator.prototype": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -6249,6 +6823,34 @@
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/magicast": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+			"integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.29.3",
+				"@babel/types": "^7.29.0",
+				"source-map-js": "^1.2.1"
+			}
+		},
+		"node_modules/make-dir": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+			"integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/math-intrinsics": {
@@ -7219,6 +7821,20 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/obug": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+			"integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/sxzz",
+				"https://opencollective.com/debug"
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
 		"node_modules/optimism": {
 			"version": "0.18.1",
 			"resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.1.tgz",
@@ -7380,6 +7996,13 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -7410,9 +8033,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.14",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-			"integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+			"version": "8.5.16",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+			"integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
 			"dev": true,
 			"funding": [
 				{
@@ -7431,7 +8054,7 @@
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"nanoid": "^3.3.11",
+				"nanoid": "^3.3.12",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -8193,6 +8816,40 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/rolldown": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
+			"integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@oxc-project/types": "=0.138.0",
+				"@rolldown/pluginutils": "^1.0.0"
+			},
+			"bin": {
+				"rolldown": "bin/cli.mjs"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"optionalDependencies": {
+				"@rolldown/binding-android-arm64": "1.1.4",
+				"@rolldown/binding-darwin-arm64": "1.1.4",
+				"@rolldown/binding-darwin-x64": "1.1.4",
+				"@rolldown/binding-freebsd-x64": "1.1.4",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
+				"@rolldown/binding-linux-arm64-gnu": "1.1.4",
+				"@rolldown/binding-linux-arm64-musl": "1.1.4",
+				"@rolldown/binding-linux-ppc64-gnu": "1.1.4",
+				"@rolldown/binding-linux-s390x-gnu": "1.1.4",
+				"@rolldown/binding-linux-x64-gnu": "1.1.4",
+				"@rolldown/binding-linux-x64-musl": "1.1.4",
+				"@rolldown/binding-openharmony-arm64": "1.1.4",
+				"@rolldown/binding-wasm32-wasi": "1.1.4",
+				"@rolldown/binding-win32-arm64-msvc": "1.1.4",
+				"@rolldown/binding-win32-x64-msvc": "1.1.4"
+			}
+		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -8521,6 +9178,13 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/source-map": {
 			"version": "0.8.0-beta.0",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
@@ -8557,6 +9221,20 @@
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
 			"integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/std-env": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+			"integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -8908,10 +9586,27 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+			"integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/tinyglobby": {
-			"version": "0.2.16",
-			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-			"integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+			"integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8955,6 +9650,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+			"integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/to-regex-range": {
@@ -9408,6 +10113,202 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/vite": {
+			"version": "8.1.3",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
+			"integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"lightningcss": "^1.32.0",
+				"picomatch": "^4.0.4",
+				"postcss": "^8.5.16",
+				"rolldown": "~1.1.3",
+				"tinyglobby": "^0.2.17"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"@vitejs/devtools": "^0.3.0",
+				"esbuild": "^0.27.0 || ^0.28.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"@vitejs/devtools": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vite/node_modules/picomatch": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/vitest": {
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+			"integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@vitest/expect": "4.1.9",
+				"@vitest/mocker": "4.1.9",
+				"@vitest/pretty-format": "4.1.9",
+				"@vitest/runner": "4.1.9",
+				"@vitest/snapshot": "4.1.9",
+				"@vitest/spy": "4.1.9",
+				"@vitest/utils": "4.1.9",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.9",
+				"@vitest/browser-preview": "4.1.9",
+				"@vitest/browser-webdriverio": "4.1.9",
+				"@vitest/coverage-istanbul": "4.1.9",
+				"@vitest/coverage-v8": "4.1.9",
+				"@vitest/ui": "4.1.9",
+				"happy-dom": "*",
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"vite": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/vitest/node_modules/picomatch": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/webidl-conversions": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
@@ -9528,6 +10429,23 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -478,6 +478,28 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@emnapi/core": {
+			"version": "1.11.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+			"integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.2",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.11.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+			"integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
 		"node_modules/@emnapi/wasi-threads": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
 		"lint": "eslint src",
 		"lint-fix": "eslint src --fix",
 		"prettier": "prettier --write .",
-		"types": "tsc --noEmit"
+		"types": "tsc --noEmit",
+		"test": "vitest run",
+		"test:watch": "vitest"
 	},
 	"dependencies": {
 		"@ai-sdk/anthropic": "^3.0.85",
@@ -34,6 +36,7 @@
 		"@types/node": "^20",
 		"@types/react": "19.2.14",
 		"@types/react-dom": "19.2.3",
+		"@vitest/coverage-v8": "^4.1.9",
 		"cssnano": "^7.1.0",
 		"daisyui": "^5.0.50",
 		"eslint": "^9",
@@ -45,7 +48,8 @@
 		"eslint-plugin-react-hooks": "^5.2.0",
 		"tailwindcss": "^4",
 		"typescript": "^5",
-		"typescript-eslint": "^8.40.0"
+		"typescript-eslint": "^8.40.0",
+		"vitest": "^4.1.9"
 	},
 	"overrides": {
 		"@types/react": "19.2.14",

--- a/src/app/api/assistant/chat/route.test.ts
+++ b/src/app/api/assistant/chat/route.test.ts
@@ -1,0 +1,158 @@
+import { NextRequest } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/supabase/server', () => ({ serverClient: vi.fn() }))
+vi.mock('@/lib/supabase/admin', () => ({ adminClient: vi.fn() }))
+vi.mock('@/lib/ai/crypto', () => ({
+	decryptApiKey: vi.fn().mockReturnValue('sk-ant-key'),
+}))
+vi.mock('@/lib/ai/tools', () => ({
+	createAssistantTools: vi.fn().mockReturnValue({}),
+}))
+vi.mock('ai', () => ({
+	convertToModelMessages: vi.fn().mockResolvedValue([]),
+	stepCountIs: vi.fn().mockReturnValue(() => false),
+	streamText: vi.fn(),
+}))
+vi.mock('@ai-sdk/anthropic', () => {
+	const instance = Object.assign(vi.fn().mockReturnValue({}), {
+		tools: { webSearch_20260209: vi.fn().mockReturnValue({}) },
+	})
+	return { createAnthropic: vi.fn().mockReturnValue(instance) }
+})
+
+import { POST } from './route'
+import { decryptApiKey } from '@/lib/ai/crypto'
+import { adminClient } from '@/lib/supabase/admin'
+import { serverClient } from '@/lib/supabase/server'
+
+import { streamText } from 'ai'
+
+const DEFAULT_USER = { id: 'user-1' }
+const DEFAULT_MEMBERSHIP = { household_id: 'hh-1', role: 'Leader' }
+const DEFAULT_KEY_ROW = { ciphertext: 'c', iv: 'i', auth_tag: 'a' }
+
+interface SetupMocksOptions {
+	user?: Record<string, unknown> | null
+	membership?: Record<string, unknown> | null
+	keyRow?: Record<string, unknown> | null
+}
+
+function setupMocks({
+	user = DEFAULT_USER,
+	membership = DEFAULT_MEMBERSHIP,
+	keyRow = DEFAULT_KEY_ROW,
+}: SetupMocksOptions = {}) {
+	const membersChain = {
+		select: vi.fn().mockReturnThis(),
+		eq: vi.fn().mockReturnThis(),
+		single: vi.fn().mockResolvedValue({ data: membership }),
+	}
+	vi.mocked(serverClient).mockResolvedValue({
+		auth: { getUser: vi.fn().mockResolvedValue({ data: { user } }) },
+		from: vi.fn().mockReturnValue(membersChain),
+	} as any)
+
+	const adminChain = {
+		select: vi.fn().mockReturnThis(),
+		eq: vi.fn().mockReturnThis(),
+		single: vi.fn().mockResolvedValue({ data: keyRow }),
+	}
+	vi.mocked(adminClient).mockReturnValue({
+		from: vi.fn().mockReturnValue(adminChain),
+	} as any)
+}
+
+function makeRequest(body: unknown = { messages: [] }) {
+	return new NextRequest('http://localhost/api/assistant/chat', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(body),
+	})
+}
+
+beforeEach(() => {
+	vi.clearAllMocks()
+	vi.mocked(decryptApiKey).mockReturnValue('sk-ant-key')
+	vi.mocked(streamText).mockReturnValue({
+		toUIMessageStreamResponse: vi
+			.fn()
+			.mockReturnValue(new Response('ok', { status: 200 })),
+	} as any)
+})
+
+describe('POST /api/assistant/chat — auth guards', () => {
+	it('returns 401 when the user is not authenticated', async () => {
+		setupMocks({ user: null })
+		const res = await POST(makeRequest())
+		expect(res.status).toBe(401)
+	})
+
+	it('returns 403 when the user has no household membership', async () => {
+		setupMocks({ membership: null })
+		const res = await POST(makeRequest())
+		expect(res.status).toBe(403)
+	})
+
+	it('returns 403 when the user has the Member role', async () => {
+		setupMocks({ membership: { household_id: 'hh-1', role: 'Member' } })
+		const res = await POST(makeRequest())
+		expect(res.status).toBe(403)
+	})
+
+	it('returns 404 when no AI key is configured for the household', async () => {
+		setupMocks({ keyRow: null })
+		const res = await POST(makeRequest())
+		expect(res.status).toBe(404)
+	})
+})
+
+describe('POST /api/assistant/chat — decryption and body parsing', () => {
+	it('returns 500 when decrypting the API key throws', async () => {
+		setupMocks()
+		vi.mocked(decryptApiKey).mockImplementationOnce(() => {
+			throw new Error('tampered')
+		})
+		const res = await POST(makeRequest())
+		expect(res.status).toBe(500)
+	})
+
+	it('returns 400 when the request body is not valid JSON', async () => {
+		setupMocks()
+		const req = new NextRequest('http://localhost/api/assistant/chat', {
+			method: 'POST',
+			body: '{not valid json}',
+		})
+		const res = await POST(req)
+		expect(res.status).toBe(400)
+	})
+})
+
+describe('POST /api/assistant/chat — provider error mapping', () => {
+	it('returns 422 when streamText throws an authentication error', async () => {
+		setupMocks()
+		vi.mocked(streamText).mockImplementationOnce(() => {
+			throw new Error('Invalid API key — authentication failed')
+		})
+		const res = await POST(makeRequest())
+		expect(res.status).toBe(422)
+	})
+
+	it('returns 429 when streamText throws a rate-limit error', async () => {
+		setupMocks()
+		vi.mocked(streamText).mockImplementationOnce(() => {
+			throw new Error('rate limit exceeded')
+		})
+		const res = await POST(makeRequest())
+		expect(res.status).toBe(429)
+	})
+
+	it('returns 502 when streamText throws a generic provider error', async () => {
+		setupMocks()
+		vi.mocked(streamText).mockImplementationOnce(() => {
+			throw new Error('upstream provider unavailable')
+		})
+		const res = await POST(makeRequest())
+		expect(res.status).toBe(502)
+	})
+})

--- a/src/app/auth/callback/route.test.ts
+++ b/src/app/auth/callback/route.test.ts
@@ -1,0 +1,72 @@
+import { NextRequest } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/supabase/server', () => ({ serverClient: vi.fn() }))
+
+import { GET } from './route'
+import { serverClient } from '@/lib/supabase/server'
+
+function makeSupabaseMock(exchangeError: unknown = null) {
+	vi.mocked(serverClient).mockResolvedValue({
+		auth: {
+			exchangeCodeForSession: vi
+				.fn()
+				.mockResolvedValue({ error: exchangeError }),
+		},
+	} as any)
+}
+
+function makeRequest(params: Record<string, string> = {}) {
+	const url = new URL('http://localhost/auth/callback')
+	for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v)
+	return new NextRequest(url.toString())
+}
+
+function locationOf(res: Response): string {
+	return res.headers.get('location') ?? ''
+}
+
+beforeEach(() => {
+	vi.clearAllMocks()
+})
+
+describe('GET /auth/callback', () => {
+	it('redirects to /auth/login when no code param is present', async () => {
+		const res = await GET(makeRequest())
+		expect(locationOf(res)).toBe('http://localhost/auth/login')
+	})
+
+	it('redirects to / when the code exchange succeeds and next is not set', async () => {
+		makeSupabaseMock(null)
+		const res = await GET(makeRequest({ code: 'abc123' }))
+		expect(locationOf(res)).toBe('http://localhost/')
+	})
+
+	it('redirects to the next param path on a successful exchange', async () => {
+		makeSupabaseMock(null)
+		const res = await GET(makeRequest({ code: 'abc123', next: '/dashboard' }))
+		expect(locationOf(res)).toBe('http://localhost/dashboard')
+	})
+
+	it('redirects to /auth/login when the code exchange fails', async () => {
+		makeSupabaseMock({ message: 'expired' })
+		const res = await GET(makeRequest({ code: 'badcode' }))
+		expect(locationOf(res)).toBe('http://localhost/auth/login')
+	})
+
+	it('blocks open redirects: redirects to / when next starts with //', async () => {
+		makeSupabaseMock(null)
+		const res = await GET(
+			makeRequest({ code: 'abc', next: '//evil.com/steal' }),
+		)
+		expect(locationOf(res)).toBe('http://localhost/')
+	})
+
+	it('blocks open redirects: redirects to / when next is an absolute URL', async () => {
+		makeSupabaseMock(null)
+		const res = await GET(
+			makeRequest({ code: 'abc', next: 'https://evil.com' }),
+		)
+		expect(locationOf(res)).toBe('http://localhost/')
+	})
+})

--- a/src/app/auth/forgot-password/actions.test.ts
+++ b/src/app/auth/forgot-password/actions.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/supabase/server', () => ({ serverClient: vi.fn() }))
+
+import { requestPasswordReset } from './actions'
+import { serverClient } from '@/lib/supabase/server'
+
+function makeFormData(fields: Record<string, string>): FormData {
+	const fd = new FormData()
+	for (const [k, v] of Object.entries(fields)) fd.append(k, v)
+	return fd
+}
+
+function makeSupabaseMock(resetError: unknown = null) {
+	vi.mocked(serverClient).mockResolvedValue({
+		auth: {
+			resetPasswordForEmail: vi.fn().mockResolvedValue({ error: resetError }),
+		},
+	} as any)
+}
+
+const prevState = { error: '', sent: false }
+
+beforeEach(() => {
+	vi.clearAllMocks()
+	process.env.NEXT_PUBLIC_SITE_URL = 'https://snacksby.app'
+})
+
+describe('requestPasswordReset', () => {
+	it('returns an error without calling Supabase when email is empty', async () => {
+		const result = await requestPasswordReset(
+			prevState,
+			makeFormData({ email: '' }),
+		)
+		expect(result).toEqual({ error: 'Email is required.', sent: false })
+		expect(serverClient).not.toHaveBeenCalled()
+	})
+
+	it('throws when NEXT_PUBLIC_SITE_URL is not set', async () => {
+		makeSupabaseMock()
+		delete process.env.NEXT_PUBLIC_SITE_URL
+		await expect(
+			requestPasswordReset(
+				prevState,
+				makeFormData({ email: 'test@example.com' }),
+			),
+		).rejects.toThrow('NEXT_PUBLIC_SITE_URL is not configured')
+	})
+
+	it('calls resetPasswordForEmail with the correct redirectTo URL', async () => {
+		const mockResetPassword = vi.fn().mockResolvedValue({ error: null })
+		vi.mocked(serverClient).mockResolvedValue({
+			auth: { resetPasswordForEmail: mockResetPassword },
+		} as any)
+
+		await requestPasswordReset(
+			prevState,
+			makeFormData({ email: 'test@example.com' }),
+		)
+
+		expect(mockResetPassword).toHaveBeenCalledWith('test@example.com', {
+			redirectTo:
+				'https://snacksby.app/auth/callback?next=/auth/reset-password',
+		})
+	})
+
+	it('always returns sent: true regardless of whether the email exists', async () => {
+		makeSupabaseMock({ message: 'User not found' })
+		const result = await requestPasswordReset(
+			prevState,
+			makeFormData({ email: 'notreal@example.com' }),
+		)
+		expect(result).toEqual({ error: '', sent: true })
+	})
+})

--- a/src/app/auth/login/actions.test.ts
+++ b/src/app/auth/login/actions.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/supabase/server', () => ({ serverClient: vi.fn() }))
+vi.mock('next/headers', () => ({ cookies: vi.fn() }))
+vi.mock('next/navigation', () => ({ redirect: vi.fn() }))
+
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+import { login } from './actions'
+import { serverClient } from '@/lib/supabase/server'
+
+function makeFormData(fields: Record<string, string>): FormData {
+	const fd = new FormData()
+	for (const [k, v] of Object.entries(fields)) fd.append(k, v)
+	return fd
+}
+
+const prevState = { error: '', resetFields: false }
+const validCredentials = makeFormData({
+	email: 'user@example.com',
+	password: 'password123',
+})
+
+function makeSupabaseMock(signInError: unknown = null) {
+	vi.mocked(serverClient).mockResolvedValue({
+		auth: {
+			signInWithPassword: vi.fn().mockResolvedValue({ error: signInError }),
+		},
+	} as any)
+}
+
+function makeCookiesMock(pendingInvite?: string) {
+	const mockDelete = vi.fn()
+	vi.mocked(cookies).mockResolvedValue({
+		get: vi
+			.fn()
+			.mockReturnValue(pendingInvite ? { value: pendingInvite } : undefined),
+		delete: mockDelete,
+	} as any)
+	return { mockDelete }
+}
+
+beforeEach(() => {
+	vi.clearAllMocks()
+})
+
+describe('login', () => {
+	it('returns the Supabase error message when sign-in fails', async () => {
+		makeSupabaseMock({ message: 'Invalid login credentials' })
+		makeCookiesMock()
+		const result = await login(prevState, validCredentials)
+		expect(result).toEqual({
+			error: 'Invalid login credentials',
+			resetFields: true,
+		})
+	})
+
+	it('redirects to / on success when there is no pending invite', async () => {
+		makeSupabaseMock(null)
+		makeCookiesMock()
+		await login(prevState, validCredentials)
+		expect(redirect).toHaveBeenCalledWith('/')
+	})
+
+	it('redirects to the join URL and deletes the cookie when a pending invite exists', async () => {
+		makeSupabaseMock(null)
+		const { mockDelete } = makeCookiesMock('abc-123')
+		await login(prevState, validCredentials)
+		expect(mockDelete).toHaveBeenCalledWith('pending_invite')
+		expect(redirect).toHaveBeenCalledWith(
+			`/join?code=${encodeURIComponent('abc-123')}`,
+		)
+	})
+
+	it('applies encodeURIComponent to the invite code', async () => {
+		makeSupabaseMock(null)
+		makeCookiesMock('code with spaces & special=chars')
+		await login(prevState, validCredentials)
+		expect(redirect).toHaveBeenCalledWith(
+			`/join?code=${encodeURIComponent('code with spaces & special=chars')}`,
+		)
+	})
+})

--- a/src/app/auth/reset-password/actions.test.ts
+++ b/src/app/auth/reset-password/actions.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/supabase/server', () => ({
+	serverClient: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+	redirect: vi.fn(),
+}))
+
+import { redirect } from 'next/navigation'
+
+import { resetPassword } from './actions'
+import { serverClient } from '@/lib/supabase/server'
+
+function makeFormData(fields: Record<string, string>): FormData {
+	const fd = new FormData()
+	for (const [k, v] of Object.entries(fields)) fd.append(k, v)
+	return fd
+}
+
+function makeSupabaseMock(session: unknown, updateError: unknown = null) {
+	const updateUser = vi.fn().mockResolvedValue({ error: updateError })
+	vi.mocked(serverClient).mockResolvedValue({
+		auth: {
+			getSession: vi.fn().mockResolvedValue({ data: { session } }),
+			updateUser,
+		},
+	} as any)
+	return { updateUser }
+}
+
+function makeRecoveryToken(): string {
+	const payload = { amr: [{ method: 'recovery' }] }
+	return `header.${Buffer.from(JSON.stringify(payload)).toString('base64')}.sig`
+}
+
+beforeEach(() => {
+	vi.clearAllMocks()
+})
+
+describe('resetPassword — validation', () => {
+	it('returns an error when passwords do not match', async () => {
+		const result = await resetPassword(
+			{ error: '' },
+			makeFormData({ password: 'password1', confirmPassword: 'password2' }),
+		)
+		expect(result).toEqual({ error: 'Passwords do not match.' })
+	})
+
+	it('returns an error when the password is fewer than 8 characters', async () => {
+		const result = await resetPassword(
+			{ error: '' },
+			makeFormData({ password: 'short', confirmPassword: 'short' }),
+		)
+		expect(result).toEqual({ error: 'Password must be at least 8 characters.' })
+	})
+})
+
+describe('resetPassword — session check', () => {
+	it('returns the expired-link error when there is no session', async () => {
+		makeSupabaseMock(null)
+		const result = await resetPassword(
+			{ error: '' },
+			makeFormData({ password: 'validpass', confirmPassword: 'validpass' }),
+		)
+		expect(result).toEqual({
+			error: 'Password reset link has expired. Please request a new one.',
+		})
+	})
+
+	it('returns the expired-link error when the session amr is not a recovery method', async () => {
+		const payload = { amr: [{ method: 'otp' }] }
+		const token = `header.${Buffer.from(JSON.stringify(payload)).toString('base64')}.sig`
+		makeSupabaseMock({ access_token: token })
+
+		const result = await resetPassword(
+			{ error: '' },
+			makeFormData({ password: 'validpass', confirmPassword: 'validpass' }),
+		)
+		expect(result).toEqual({
+			error: 'Password reset link has expired. Please request a new one.',
+		})
+	})
+
+	it('calls updateUser with the new password on a valid recovery session', async () => {
+		const { updateUser } = makeSupabaseMock({
+			access_token: makeRecoveryToken(),
+		})
+
+		await resetPassword(
+			{ error: '' },
+			makeFormData({ password: 'validpass', confirmPassword: 'validpass' }),
+		)
+
+		expect(updateUser).toHaveBeenCalledWith({ password: 'validpass' })
+	})
+
+	it('redirects to / on successful password update', async () => {
+		makeSupabaseMock({ access_token: makeRecoveryToken() })
+
+		await resetPassword(
+			{ error: '' },
+			makeFormData({ password: 'validpass', confirmPassword: 'validpass' }),
+		)
+
+		expect(redirect).toHaveBeenCalledWith('/')
+	})
+
+	it('returns the server error message when updateUser fails', async () => {
+		makeSupabaseMock(
+			{ access_token: makeRecoveryToken() },
+			{ message: 'Password too weak.' },
+		)
+
+		const result = await resetPassword(
+			{ error: '' },
+			makeFormData({ password: 'validpass', confirmPassword: 'validpass' }),
+		)
+
+		expect(result).toEqual({ error: 'Password too weak.' })
+	})
+})

--- a/src/app/join/actions.test.ts
+++ b/src/app/join/actions.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('next/headers', () => ({ cookies: vi.fn() }))
+vi.mock('next/navigation', () => ({ redirect: vi.fn() }))
+
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+import { storeInviteAndRedirect } from './actions'
+
+function makeFormData(fields: Record<string, string>): FormData {
+	const fd = new FormData()
+	for (const [k, v] of Object.entries(fields)) fd.append(k, v)
+	return fd
+}
+
+function makeCookiesMock() {
+	const mockSet = vi.fn()
+	vi.mocked(cookies).mockResolvedValue({ set: mockSet } as any)
+	return { mockSet }
+}
+
+beforeEach(() => {
+	vi.clearAllMocks()
+})
+
+afterEach(() => {
+	vi.unstubAllEnvs()
+})
+
+describe('storeInviteAndRedirect', () => {
+	it('sets the pending_invite cookie with httpOnly and 15-minute maxAge', async () => {
+		const { mockSet } = makeCookiesMock()
+		await storeInviteAndRedirect(
+			'inv-code',
+			makeFormData({ destination: '/join' }),
+		)
+		expect(mockSet).toHaveBeenCalledWith(
+			'pending_invite',
+			'inv-code',
+			expect.objectContaining({ httpOnly: true, maxAge: 900 }),
+		)
+	})
+
+	it('sets secure: false outside production', async () => {
+		const { mockSet } = makeCookiesMock()
+		vi.stubEnv('NODE_ENV', 'test')
+		await storeInviteAndRedirect(
+			'inv-code',
+			makeFormData({ destination: '/join' }),
+		)
+		expect(mockSet).toHaveBeenCalledWith(
+			'pending_invite',
+			'inv-code',
+			expect.objectContaining({ secure: false }),
+		)
+	})
+
+	it('sets secure: true in production', async () => {
+		const { mockSet } = makeCookiesMock()
+		vi.stubEnv('NODE_ENV', 'production')
+		await storeInviteAndRedirect(
+			'inv-code',
+			makeFormData({ destination: '/join' }),
+		)
+		expect(mockSet).toHaveBeenCalledWith(
+			'pending_invite',
+			'inv-code',
+			expect.objectContaining({ secure: true }),
+		)
+	})
+
+	it('redirects to the destination from the form', async () => {
+		makeCookiesMock()
+		await storeInviteAndRedirect(
+			'inv-code',
+			makeFormData({ destination: '/join?code=inv-code' }),
+		)
+		expect(redirect).toHaveBeenCalledWith('/join?code=inv-code')
+	})
+})

--- a/src/app/settings/household/actions.test.ts
+++ b/src/app/settings/household/actions.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/supabase/server', () => ({ serverClient: vi.fn() }))
+vi.mock('@/lib/supabase/admin', () => ({ adminClient: vi.fn() }))
+vi.mock('@/lib/ai/crypto', () => ({ encryptApiKey: vi.fn() }))
+vi.mock('ai', () => ({ generateText: vi.fn().mockResolvedValue({}) }))
+vi.mock('@ai-sdk/anthropic', () => ({
+	createAnthropic: vi.fn().mockReturnValue(vi.fn().mockReturnValue({})),
+}))
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+
+import {
+	getAiKeyStatus,
+	removeAiKey,
+	resetInviteCode,
+	saveAiKey,
+} from './actions'
+import { encryptApiKey } from '@/lib/ai/crypto'
+import { adminClient } from '@/lib/supabase/admin'
+import { serverClient } from '@/lib/supabase/server'
+
+import { generateText } from 'ai'
+
+interface ServerClientOptions {
+	user?: Record<string, unknown> | null
+	membershipData?: Record<string, unknown> | null
+	upsertError?: { message: string } | null
+	deleteError?: { message: string } | null
+	rpcError?: { message: string } | null
+}
+
+function makeServerClient({
+	user = { id: 'user-1' },
+	membershipData = { role: 'Leader' },
+	upsertError = null,
+	deleteError = null,
+	rpcError = null,
+}: ServerClientOptions = {}) {
+	const membersChain = {
+		select: vi.fn().mockReturnThis(),
+		eq: vi.fn().mockReturnThis(),
+		single: vi.fn().mockResolvedValue({ data: membershipData }),
+	}
+
+	// Supports both .upsert() and .delete().eq() on the same table
+	const keysChain = {
+		upsert: vi.fn().mockResolvedValue({ error: upsertError }),
+		delete: vi.fn().mockReturnThis(),
+		eq: vi.fn().mockResolvedValue({ error: deleteError }),
+	}
+
+	vi.mocked(serverClient).mockResolvedValue({
+		auth: {
+			getUser: vi.fn().mockResolvedValue({ data: { user } }),
+		},
+		from: vi.fn().mockImplementation((table: string) => {
+			if (table === 'household_members') return membersChain
+			if (table === 'household_ai_keys') return keysChain
+			return {}
+		}),
+		rpc: vi.fn().mockResolvedValue({ error: rpcError }),
+	} as any)
+
+	return { membersChain, keysChain }
+}
+
+function makeAdminClient(keyRow: Record<string, unknown> | null = null) {
+	const chain = {
+		select: vi.fn().mockReturnThis(),
+		eq: vi.fn().mockReturnThis(),
+		single: vi.fn().mockResolvedValue({ data: keyRow }),
+	}
+	vi.mocked(adminClient).mockReturnValue({
+		from: vi.fn().mockReturnValue(chain),
+	} as any)
+}
+
+beforeEach(() => {
+	vi.clearAllMocks()
+	vi.mocked(encryptApiKey).mockReturnValue({
+		ciphertext: 'c',
+		iv: 'i',
+		auth_tag: 'a',
+	})
+})
+
+describe('getAiKeyStatus', () => {
+	it('returns set: false when no key row exists', async () => {
+		makeAdminClient(null)
+		expect(await getAiKeyStatus('hh-1')).toEqual({ set: false, last4: null })
+	})
+
+	it('returns set: true with last4 when a key row exists', async () => {
+		makeAdminClient({ key_last4: '1234' })
+		expect(await getAiKeyStatus('hh-1')).toEqual({ set: true, last4: '1234' })
+	})
+})
+
+describe('resetInviteCode', () => {
+	it('throws when the RPC returns an error', async () => {
+		makeServerClient({ rpcError: { message: 'RPC failed' } })
+		await expect(resetInviteCode('hh-1')).rejects.toThrow('RPC failed')
+	})
+
+	it('resolves without error on success', async () => {
+		makeServerClient()
+		await expect(resetInviteCode('hh-1')).resolves.toBeUndefined()
+	})
+})
+
+describe('saveAiKey', () => {
+	it('returns an error when the user is not authenticated', async () => {
+		makeServerClient({ user: null })
+		expect(await saveAiKey('hh-1', 'sk-ant-valid')).toEqual({
+			error: 'Not authenticated.',
+		})
+	})
+
+	it('returns an error when the user is not a Leader', async () => {
+		makeServerClient({ membershipData: { role: 'Member' } })
+		expect(await saveAiKey('hh-1', 'sk-ant-valid')).toEqual({
+			error: 'Only Leaders can manage the AI key.',
+		})
+	})
+
+	it('returns an error when the key does not start with sk-ant-', async () => {
+		makeServerClient()
+		expect(await saveAiKey('hh-1', 'sk-openai-oops')).toEqual({
+			error: 'Invalid key — Anthropic keys start with sk-ant-.',
+		})
+	})
+
+	it('returns an error when Anthropic key validation fails', async () => {
+		makeServerClient()
+		vi.mocked(generateText).mockRejectedValueOnce(
+			new Error('authentication_error'),
+		)
+		expect(await saveAiKey('hh-1', 'sk-ant-badkey')).toEqual({
+			error: 'Key validation failed — check it is correct and active.',
+		})
+	})
+
+	it('returns an error when the upsert fails', async () => {
+		makeServerClient({ upsertError: { message: 'DB write failed' } })
+		expect(await saveAiKey('hh-1', 'sk-ant-validkey')).toEqual({
+			error: 'DB write failed',
+		})
+	})
+
+	it('encrypts and upserts on success', async () => {
+		const { keysChain } = makeServerClient()
+		const result = await saveAiKey('hh-1', 'sk-ant-validkey')
+		expect(result).toEqual({})
+		expect(encryptApiKey).toHaveBeenCalledWith('sk-ant-validkey')
+		expect(keysChain.upsert).toHaveBeenCalledWith(
+			expect.objectContaining({
+				ciphertext: 'c',
+				iv: 'i',
+				auth_tag: 'a',
+				key_last4: 'dkey',
+			}),
+			{ onConflict: 'household_id' },
+		)
+	})
+})
+
+describe('removeAiKey', () => {
+	it('returns an error when the user is not authenticated', async () => {
+		makeServerClient({ user: null })
+		expect(await removeAiKey('hh-1')).toEqual({ error: 'Not authenticated.' })
+	})
+
+	it('returns an error when the user is not a Leader', async () => {
+		makeServerClient({ membershipData: { role: 'Contributor' } })
+		expect(await removeAiKey('hh-1')).toEqual({
+			error: 'Only Leaders can manage the AI key.',
+		})
+	})
+
+	it('returns an error when the delete fails', async () => {
+		makeServerClient({ deleteError: { message: 'Delete failed' } })
+		expect(await removeAiKey('hh-1')).toEqual({ error: 'Delete failed' })
+	})
+
+	it('returns an empty object on success', async () => {
+		makeServerClient()
+		expect(await removeAiKey('hh-1')).toEqual({})
+	})
+})

--- a/src/lib/ai/crypto.test.ts
+++ b/src/lib/ai/crypto.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { decryptApiKey, encryptApiKey } from './crypto'
+
+const VALID_SECRET = Buffer.alloc(32).toString('base64')
+
+beforeEach(() => {
+	process.env.AI_KEY_ENCRYPTION_SECRET = VALID_SECRET
+})
+
+describe('encryptApiKey / decryptApiKey', () => {
+	it('round-trips plaintext correctly', () => {
+		const plaintext = 'sk-ant-api03-super-secret-key'
+		expect(decryptApiKey(encryptApiKey(plaintext))).toBe(plaintext)
+	})
+
+	it('produces a different IV on each call', () => {
+		const a = encryptApiKey('same-key')
+		const b = encryptApiKey('same-key')
+		expect(a.iv).not.toBe(b.iv)
+		expect(a.ciphertext).not.toBe(b.ciphertext)
+	})
+
+	it('throws when the auth tag is tampered with', () => {
+		const encrypted = encryptApiKey('sk-ant-api03-real-key')
+		const tampered = {
+			...encrypted,
+			auth_tag: Buffer.alloc(16).toString('base64'),
+		}
+		expect(() => decryptApiKey(tampered)).toThrow()
+	})
+
+	it('throws when the ciphertext is tampered with', () => {
+		const encrypted = encryptApiKey('sk-ant-api03-real-key')
+		const buf = Buffer.from(encrypted.ciphertext, 'base64')
+		buf[0] ^= 0xff
+		expect(() =>
+			decryptApiKey({ ...encrypted, ciphertext: buf.toString('base64') }),
+		).toThrow()
+	})
+})
+
+describe('getMasterKey (via encryptApiKey)', () => {
+	it('throws when AI_KEY_ENCRYPTION_SECRET is not set', () => {
+		delete process.env.AI_KEY_ENCRYPTION_SECRET
+		expect(() => encryptApiKey('anything')).toThrow(
+			'AI_KEY_ENCRYPTION_SECRET is not set',
+		)
+	})
+
+	it('throws when the secret decodes to fewer than 32 bytes', () => {
+		process.env.AI_KEY_ENCRYPTION_SECRET = Buffer.alloc(16).toString('base64')
+		expect(() => encryptApiKey('anything')).toThrow('must decode to 32 bytes')
+	})
+
+	it('throws when the secret decodes to more than 32 bytes', () => {
+		process.env.AI_KEY_ENCRYPTION_SECRET = Buffer.alloc(64).toString('base64')
+		expect(() => encryptApiKey('anything')).toThrow('must decode to 32 bytes')
+	})
+})

--- a/src/lib/ai/recipe-schema.test.ts
+++ b/src/lib/ai/recipe-schema.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+
+import { RecipeProposalSchema } from './recipe-schema'
+
+const minimalValid = {
+	title: 'Pasta',
+	ingredients: [{ name: 'pasta', amount: 200, unit: 'g' as const }],
+	method: [{ step: 1, instruction: 'Cook pasta until al dente.' }],
+}
+
+describe('RecipeProposalSchema', () => {
+	it('accepts a minimal valid recipe', () => {
+		expect(RecipeProposalSchema.safeParse(minimalValid).success).toBe(true)
+	})
+
+	it('rejects a recipe with no title', () => {
+		expect(
+			RecipeProposalSchema.safeParse({ ...minimalValid, title: '' }).success,
+		).toBe(false)
+	})
+
+	it('rejects a recipe with an empty ingredients array', () => {
+		expect(
+			RecipeProposalSchema.safeParse({ ...minimalValid, ingredients: [] })
+				.success,
+		).toBe(false)
+	})
+
+	it('rejects an ingredient with an amount of zero', () => {
+		const withZeroAmount = {
+			...minimalValid,
+			ingredients: [{ name: 'pasta', amount: 0, unit: 'g' as const }],
+		}
+		expect(RecipeProposalSchema.safeParse(withZeroAmount).success).toBe(false)
+	})
+
+	it('rejects an ingredient with a negative amount', () => {
+		const withNegativeAmount = {
+			...minimalValid,
+			ingredients: [{ name: 'pasta', amount: -100, unit: 'g' as const }],
+		}
+		expect(RecipeProposalSchema.safeParse(withNegativeAmount).success).toBe(
+			false,
+		)
+	})
+
+	it('accepts unit: null for countable items', () => {
+		const withNullUnit = {
+			...minimalValid,
+			ingredients: [{ name: 'eggs', amount: 2, unit: null }],
+		}
+		expect(RecipeProposalSchema.safeParse(withNullUnit).success).toBe(true)
+	})
+
+	it('defaults tags to an empty array when omitted', () => {
+		const result = RecipeProposalSchema.safeParse(minimalValid)
+		expect(result.success && result.data.tags).toEqual([])
+	})
+
+	it('defaults visibility to private when omitted', () => {
+		const result = RecipeProposalSchema.safeParse(minimalValid)
+		expect(result.success && result.data.visibility).toBe('private')
+	})
+
+	it('rejects a recipe with an empty method array', () => {
+		expect(
+			RecipeProposalSchema.safeParse({ ...minimalValid, method: [] }).success,
+		).toBe(false)
+	})
+})

--- a/src/lib/graphql/shopping-list.test.ts
+++ b/src/lib/graphql/shopping-list.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { guessCategory } from './shopping-list'
+
+describe('guessCategory', () => {
+	it('matches a known keyword exactly', () => {
+		expect(guessCategory('chicken')).toBe('Meat & Fish')
+	})
+
+	it('matches a keyword as a substring', () => {
+		expect(guessCategory('chicken breast')).toBe('Meat & Fish')
+	})
+
+	it('is case-insensitive', () => {
+		expect(guessCategory('MILK')).toBe('Dairy')
+	})
+
+	it('categorises produce correctly', () => {
+		expect(guessCategory('baby spinach')).toBe('Produce')
+	})
+
+	it('categorises pantry items correctly', () => {
+		expect(guessCategory('olive oil')).toBe('Pantry')
+	})
+
+	it('categorises frozen items correctly', () => {
+		expect(guessCategory('frozen peas')).toBe('Frozen')
+	})
+
+	it('categorises drinks correctly', () => {
+		expect(guessCategory('orange juice')).toBe('Drinks')
+	})
+
+	it('returns Misc for an unknown ingredient', () => {
+		expect(guessCategory('toothpaste')).toBe('Misc')
+	})
+
+	it('returns Misc for an empty string', () => {
+		expect(guessCategory('')).toBe('Misc')
+	})
+
+	it('never matches via the Misc category keywords (it has none)', () => {
+		// The loop skips Misc, so "misc" itself falls through to the Misc fallback.
+		expect(guessCategory('misc')).toBe('Misc')
+	})
+})

--- a/src/lib/units.test.ts
+++ b/src/lib/units.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseQuantityString, sumIngredients } from './units'
+
+describe('parseQuantityString', () => {
+	it('returns an empty array for null', () => {
+		expect(parseQuantityString(null)).toEqual([])
+	})
+
+	it('returns an empty array for an empty string', () => {
+		expect(parseQuantityString('')).toEqual([])
+	})
+
+	it('returns an empty array for a whitespace-only string', () => {
+		expect(parseQuantityString('   ')).toEqual([])
+	})
+
+	it('parses a quantity with a known unit', () => {
+		expect(parseQuantityString('200 g')).toEqual([{ amount: 200, unit: 'g' }])
+	})
+
+	it('parses a quantity whose unit is not in the UNITS list as null', () => {
+		expect(parseQuantityString('3 eggs')).toEqual([{ amount: 3, unit: null }])
+	})
+
+	it('parses a unitless quantity', () => {
+		expect(parseQuantityString('2')).toEqual([{ amount: 2, unit: null }])
+	})
+
+	it('parses a multi-part string separated by " + "', () => {
+		expect(parseQuantityString('200 g + 1 kg')).toEqual([
+			{ amount: 200, unit: 'g' },
+			{ amount: 1, unit: 'kg' },
+		])
+	})
+
+	it('skips malformed parts and parses valid ones', () => {
+		expect(parseQuantityString('abc + 100 ml')).toEqual([
+			{ amount: 100, unit: 'ml' },
+		])
+	})
+})
+
+describe('sumIngredients', () => {
+	it('returns an empty string for an empty array', () => {
+		expect(sumIngredients([])).toBe('')
+	})
+
+	it('sums quantities with the same unit', () => {
+		expect(
+			sumIngredients([
+				{ amount: 200, unit: 'g' },
+				{ amount: 300, unit: 'g' },
+			]),
+		).toBe('500 g')
+	})
+
+	it('normalises kg to g before summing then promotes back', () => {
+		expect(
+			sumIngredients([
+				{ amount: 500, unit: 'g' },
+				{ amount: 1, unit: 'kg' },
+			]),
+		).toBe('1.5 kg')
+	})
+
+	it('promotes g to kg when total reaches 1000', () => {
+		expect(
+			sumIngredients([
+				{ amount: 500, unit: 'g' },
+				{ amount: 500, unit: 'g' },
+			]),
+		).toBe('1 kg')
+	})
+
+	it('does not promote g to kg below the 1000 threshold', () => {
+		expect(
+			sumIngredients([
+				{ amount: 400, unit: 'g' },
+				{ amount: 599, unit: 'g' },
+			]),
+		).toBe('999 g')
+	})
+
+	it('normalises L to ml before summing then promotes back', () => {
+		expect(
+			sumIngredients([
+				{ amount: 500, unit: 'ml' },
+				{ amount: 1, unit: 'L' },
+			]),
+		).toBe('1.5 L')
+	})
+
+	it('sums unitless quantities independently of unit quantities', () => {
+		const result = sumIngredients([
+			{ amount: 2, unit: null },
+			{ amount: 3, unit: null },
+			{ amount: 100, unit: 'g' },
+		])
+		expect(result).toContain('5')
+		expect(result).toContain('100 g')
+	})
+
+	it('rounds to 2 decimal places', () => {
+		expect(
+			sumIngredients([
+				{ amount: 1 / 3, unit: 'g' },
+				{ amount: 1 / 3, unit: 'g' },
+			]),
+		).toBe('0.67 g')
+	})
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { resolve } from 'path'
+
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+	test: {
+		environment: 'node',
+	},
+	resolve: {
+		alias: {
+			'@': resolve(__dirname, './src'),
+		},
+	},
+})


### PR DESCRIPTION
## Overview
Introduces Vitest as the test framework and adds 90 tests across 11 files covering the highest-risk paths in the codebase — security-critical code, auth flows, and the AI assistant feature.

> [!TIP]
> Run `npm test` to execute the suite. No environment variables or external services required — all external dependencies are mocked.

## Changes

<details>
<summary>Test infrastructure — 3 files</summary>

- **`vitest.config.ts`** — Vitest setup with node environment and `@/` path alias matching tsconfig
- **`package.json`** — adds `vitest`, `@vitest/coverage-v8`; adds `test` and `test:watch` scripts
- **`eslint.config.mjs`** — test-file overrides disabling `no-explicit-any` and `import/order` (both conflict with Vitest's `vi.mock()` hoisting pattern)

</details>

<details>
<summary>Security & crypto — 2 files, 16 tests</summary>

- **`crypto.test.ts`** — AES-256-GCM round-trip, IV uniqueness, auth tag tamper detection, ciphertext tamper detection, missing/wrong-length secret
- **`recipe-schema.test.ts`** — Zod schema contract between AI model output and the database: required fields, `amount: positive()`, `unit: null` for countable items, default values for `tags` and `visibility`

</details>

<details>
<summary>Auth flows — 4 files, 27 tests</summary>

- **`reset-password/actions.test.ts`** — validation, recovery token check, successful update, redirect, server error passthrough
- **`login/actions.test.ts`** — auth error passthrough, success redirect, pending-invite cookie branch, `encodeURIComponent` applied to code
- **`forgot-password/actions.test.ts`** — empty email guard, missing env var throws, correct `redirectTo` URL, privacy invariant (always returns `sent: true`)
- **`callback/route.test.ts`** — no code param, successful exchange, failed exchange, open-redirect guard (`//evil.com` and absolute URLs blocked)

</details>

<details>
<summary>AI assistant — 2 files, 23 tests</summary>

- **`settings/household/actions.test.ts`** — `getAiKeyStatus`, `resetInviteCode`, `saveAiKey` (6 paths: unauthenticated, non-Leader, bad prefix, Anthropic validation failure, upsert error, happy path), `removeAiKey` (4 paths)
- **`chat/route.test.ts`** — all 3 auth layers (session, membership, Member role), no key configured, decrypt failure, malformed body, Anthropic 422/429/502 error mapping

</details>

<details>
<summary>Data & utilities — 3 files, 24 tests</summary>

- **`units.test.ts`** — `parseQuantityString` (null, empty, known unit, unknown unit, multi-part, malformed), `sumIngredients` (kg to g and L to ml normalisation, promotion thresholds, rounding)
- **`shopping-list.test.ts`** — `guessCategory` keyword matching across all categories, case-insensitive, substring match, unknown ingredient, empty string
- **`join/actions.test.ts`** — `pending_invite` cookie `httpOnly` and 15-minute `maxAge`, `secure: false` outside production, `secure: true` in production, redirect to destination

</details>

---

## Summary

Adding tests to a codebase is like installing smoke detectors — nobody thinks they need them until something's on fire at 2am. This PR installs 90 of them, all pointed at the rooms most likely to cause a problem: the safe where the API keys live, the front door (auth), and the AI assistant that controls it all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
